### PR TITLE
Fix für Preloading des kleinen Logos

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -28,15 +28,9 @@
             type="font/ttf"
             crossorigin="anonymous"
         />
-        <link 
+        <link
             rel="preload"
             href="src/assets/banner_logo.png"
-            as="image"
-            type="image/png"
-        />
-        <link 
-            rel="preload"
-            href="src/assets/logo_small.png"
             as="image"
             type="image/png"
         />

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -100,12 +100,7 @@ export const Sidebar = () => {
                             onLogin={onLogin}
                         />
                     )}
-                    <img
-                        src={smallLogo}
-                        alt="Logo"
-                        className={css.logo}
-                        loading="eager"
-                    />
+                    <img src={smallLogo} alt="Logo" className={css.logo} />
                 </>
             )}
         </div>


### PR DESCRIPTION
Das kleine Logo wird nicht mehr vorgeladen; so wird die Warnung nicht mehr geworfen. Wenn ein Benutzer angemeldet ist, entsteht kein Flickern des Bildes bei schnellem neu laden