### PR TITLE
Fixed: Zu lange Gerätenamen sorgen für Layoutprobleme

### DIFF
--- a/frontend/src/components/Sidebar/Sidebar.module.scss
+++ b/frontend/src/components/Sidebar/Sidebar.module.scss
@@ -7,6 +7,7 @@
     padding: 1rem;
     height: 100vh;
     color: #232323;
+    gap: 1rem;
 }
 
 .collapsed {
@@ -28,8 +29,7 @@
     justify-content: center;
     align-items: center;
     width: 100%;
-    margin-top: 0;
-    margin-bottom: 10px;
+    margin: 0;
     min-height: 40px;
 
     h2 {
@@ -52,6 +52,6 @@
 .logo {
     align-self: center;
     height: 7%;
-    margin-bottom: 20%;
     margin-top: auto;
+    margin-bottom: 20%;
 }

--- a/frontend/src/components/Sidebar/UserProfile/UserProfile.module.scss
+++ b/frontend/src/components/Sidebar/UserProfile/UserProfile.module.scss
@@ -38,23 +38,20 @@
     flex: 1;
     display: flex;
     flex-direction: column;
+    gap: 5px;
     min-height: 0;
+    position: relative;
+
+    :has(.registeredCurrentDevice),
+    :has(.unregisteredCurrentDevice) {
+        position: sticky;
+        top: 0;
+        z-index: 1;
+        background-color: #ebebeb;
+    }
 }
 
-.deviceListItem {
-    --buttonheight: 50px;
-
-    height: var(--buttonheight);
-    list-style: none;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 5px;
-    flex-shrink: 0;
-}
-
-.currentDevice {
+.registeredCurrentDevice {
     width: 100%;
     height: 100%;
     border-radius: 100px;
@@ -66,8 +63,8 @@
     padding: 0 0 0 15px;
 }
 
-.unregistered {
-    @extend .currentDevice;
+.unregisteredCurrentDevice {
+    @extend .registeredCurrentDevice;
 
     &:hover {
         background-color: black;
@@ -78,6 +75,18 @@
         background-color: #aaaaaa;
         cursor: not-allowed;
     }
+}
+
+.deviceListItem {
+    --buttonheight: 50px;
+
+    height: var(--buttonheight);
+    list-style: none;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    flex-shrink: 0;
 }
 
 .connectButton {
@@ -126,6 +135,7 @@
     width: 100%;
 
     p {
+        margin: 0;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;

--- a/frontend/src/components/Sidebar/UserProfile/UserProfile.module.scss
+++ b/frontend/src/components/Sidebar/UserProfile/UserProfile.module.scss
@@ -2,13 +2,13 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
     width: 100%;
     font-size: 22px;
+    overflow: hidden;
 }
 
 .profilePicture {
-    margin: 10px;
+    flex-shrink: 0;
     height: 200px;
 }
 
@@ -20,6 +20,11 @@
 
 .registeredDevices {
     width: 100%;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+
     h4 {
         margin: 0;
         font-weight: normal;
@@ -29,6 +34,11 @@
 .deviceList {
     margin: 0;
     padding: 0;
+    overflow-y: auto;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
 }
 
 .deviceListItem {
@@ -41,6 +51,7 @@
     justify-content: space-between;
     align-items: center;
     margin-bottom: 5px;
+    flex-shrink: 0;
 }
 
 .currentDevice {
@@ -74,11 +85,6 @@
         background-color: #aaaaaa;
         cursor: not-allowed;
     }
-}
-
-.addIcon {
-    height: 20px;
-    margin-right: 15px;
 }
 
 .connectButton {

--- a/frontend/src/components/Sidebar/UserProfile/UserProfile.module.scss
+++ b/frontend/src/components/Sidebar/UserProfile/UserProfile.module.scss
@@ -104,6 +104,7 @@
     height: 100%;
     width: var(--buttonheight);
     padding: 5px;
+    flex-shrink: 0;
 }
 
 .deleteButton {
@@ -122,11 +123,13 @@
 .deviceInfo {
     display: flex;
     align-items: center;
+    overflow: hidden;
+    width: 100%;
 
-    img {
-        width: 20px;
-        height: 20px;
-        margin-right: 15px;
+    p {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 }
 
@@ -136,6 +139,7 @@
     border-radius: 50%;
     display: inline-block;
     margin-right: 15px;
+    flex-shrink: 0;
 }
 
 .deviceOnline {

--- a/frontend/src/components/Sidebar/UserProfile/UserProfile.module.scss
+++ b/frontend/src/components/Sidebar/UserProfile/UserProfile.module.scss
@@ -66,15 +66,8 @@
     padding: 0 0 0 15px;
 }
 
-.addCurrentDeviceButton {
-    width: 100%;
-    height: 100%;
-    border-radius: 100px;
-    background-color: var(--black);
-    color: var(--white);
-    display: flex;
-    align-items: center;
-    padding: 0 0 0 15px;
+.unregistered {
+    @extend .currentDevice;
 
     &:hover {
         background-color: black;

--- a/frontend/src/components/Sidebar/UserProfile/UserProfile.tsx
+++ b/frontend/src/components/Sidebar/UserProfile/UserProfile.tsx
@@ -299,9 +299,7 @@ export const UserProfile = () => {
                     <li key={-1} className={css.deviceListItem}>
                         {!currentDeviceRegistered ? (
                             <button
-                                className={
-                                    css.currentDevice + " " + css.unregistered
-                                }
+                                className={css.unregisteredCurrentDevice}
                                 type="button"
                                 onClick={() => void registerCurrentDevice()}
                                 disabled={registerButtonDisabled}
@@ -315,7 +313,7 @@ export const UserProfile = () => {
                                 </span>
                             </button>
                         ) : (
-                            <div className={css.currentDevice}>
+                            <div className={css.registeredCurrentDevice}>
                                 <span className={css.deviceInfo}>
                                     <img
                                         src={userIconLight}

--- a/frontend/src/components/Sidebar/UserProfile/UserProfile.tsx
+++ b/frontend/src/components/Sidebar/UserProfile/UserProfile.tsx
@@ -346,7 +346,7 @@ export const UserProfile = () => {
                                             device.status
                                         )}
                                     ></span>
-                                    {device.name}
+                                    <p>{device.name}</p>
                                 </span>
                                 <span className={css.deleteButtonContainer}>
                                     <span

--- a/frontend/src/components/Sidebar/UserProfile/UserProfile.tsx
+++ b/frontend/src/components/Sidebar/UserProfile/UserProfile.tsx
@@ -306,15 +306,18 @@ export const UserProfile = () => {
                             >
                                 <img
                                     src={addIcon}
-                                    className={css.addIcon}
+                                    className={css.deviceStatusBase}
                                 ></img>
-                                Gerät hinzufügen
+                                <p>Gerät hinzufügen</p>
                             </button>
                         ) : (
                             <div className={css.currentDevice}>
                                 <span className={css.deviceInfo}>
-                                    <img src={userIconLight} />
-                                    Current Device
+                                    <img
+                                        src={userIconLight}
+                                        className={css.deviceStatusBase}
+                                    />
+                                    <p>Current Device</p>
                                 </span>
                                 <span className={css.deleteButtonContainer}>
                                     <span

--- a/frontend/src/components/Sidebar/UserProfile/UserProfile.tsx
+++ b/frontend/src/components/Sidebar/UserProfile/UserProfile.tsx
@@ -299,16 +299,20 @@ export const UserProfile = () => {
                     <li key={-1} className={css.deviceListItem}>
                         {!currentDeviceRegistered ? (
                             <button
-                                className={css.addCurrentDeviceButton}
+                                className={
+                                    css.currentDevice + " " + css.unregistered
+                                }
                                 type="button"
                                 onClick={() => void registerCurrentDevice()}
                                 disabled={registerButtonDisabled}
                             >
-                                <img
-                                    src={addIcon}
-                                    className={css.deviceStatusBase}
-                                ></img>
-                                <p>Gerät hinzufügen</p>
+                                <span className={css.deviceInfo}>
+                                    <img
+                                        src={addIcon}
+                                        className={css.deviceStatusBase}
+                                    ></img>
+                                    <p>Gerät hinzufügen</p>
+                                </span>
                             </button>
                         ) : (
                             <div className={css.currentDevice}>


### PR DESCRIPTION
- Zu lange Gerätenamen werden mit `...` abgekürzt
- Delete- und Status-Buttons werden nicht verzerrt
- Wenn zu viele Geräte präsent sind, wird eine Scrollbar (nur für die Registered Devices) eingeblendet und kein Overflow über die 100vh hinaus erzeugt
- Kleinere Optimierungen für sauberen Code