### PR TITLE
140 bug invalide deviceuuid führt zu problemen beim registrieren

### DIFF
--- a/backend/backend.tests/src/DeviceComponent/Logic/Impl/DeviceHandlerTest.cs
+++ b/backend/backend.tests/src/DeviceComponent/Logic/Impl/DeviceHandlerTest.cs
@@ -70,7 +70,7 @@ public class DeviceHandlerTests
     }
 
     [Test]
-    public async Task RegisterDeviceAsync_WhenDeviceAlreadyRegistered_OverridesExistingUuid()
+    public async Task RegisterDeviceAsync_WhenDeviceAlreadyRegistered_ReturnsOkWithOverrittenUuid()
     {
         Guid guid = Guid.NewGuid();
         // Arrange
@@ -83,6 +83,7 @@ public class DeviceHandlerTests
         Assert.That(result, Is.TypeOf<Ok<DeviceRegisterDto>>());
         var okResult = result as Ok<DeviceRegisterDto>;
         Assert.That(okResult?.Value, Has.Property("uuid"));
+        Assert.That(okResult?.Value!.uuid, !Is.EqualTo(guid));
     }
 
     [Test]

--- a/backend/backend.tests/src/DeviceComponent/Logic/Impl/DeviceHandlerTest.cs
+++ b/backend/backend.tests/src/DeviceComponent/Logic/Impl/DeviceHandlerTest.cs
@@ -70,7 +70,7 @@ public class DeviceHandlerTests
     }
 
     [Test]
-    public async Task RegisterDeviceAsync_WhenDeviceAlreadyRegistered_ReturnsBadRequest()
+    public async Task RegisterDeviceAsync_WhenDeviceAlreadyRegistered_OverridesExistingUuid()
     {
         Guid guid = Guid.NewGuid();
         // Arrange
@@ -80,7 +80,9 @@ public class DeviceHandlerTests
         var result = await _deviceHandler.RegisterDeviceAsync(context);
 
         // Assert
-        Assert.That(result, Is.TypeOf<BadRequest<string>>());
+        Assert.That(result, Is.TypeOf<Ok<DeviceRegisterDto>>());
+        var okResult = result as Ok<DeviceRegisterDto>;
+        Assert.That(okResult?.Value, Has.Property("uuid"));
     }
 
     [Test]

--- a/backend/backend/src/DeviceComponent/Logic/Impl/DeviceHandler.cs
+++ b/backend/backend/src/DeviceComponent/Logic/Impl/DeviceHandler.cs
@@ -22,10 +22,6 @@ public class DeviceHandler(IDeviceRepository repo, IAccountLoginHandler login, I
         {
             Console.WriteLine($"Session Token received {sessionToken}");
         }
-        if (context.Request.Cookies.ContainsKey("deviceUuid"))
-        {
-            return Results.BadRequest("Device is already registered.");
-        }
 
         var result = await login.HandleGetCurrentUser(context);
         if (result is Ok<LoginResponse> okResult)
@@ -55,7 +51,6 @@ public class DeviceHandler(IDeviceRepository repo, IAccountLoginHandler login, I
         var deviceUuid = Guid.NewGuid();
 
         // Create a new device object to save in the repository
-        //var device = new Device(displayName, deviceUuid, accountId);
         var device = Device.Of(displayName, deviceUuid, accountId);
         // Save the device to the repository (database)
         await repo.SaveDeviceAsync(device);

--- a/backend/backend/src/DeviceComponent/Logic/Impl/DeviceHandler.cs
+++ b/backend/backend/src/DeviceComponent/Logic/Impl/DeviceHandler.cs
@@ -165,13 +165,12 @@ public class DeviceHandler(IDeviceRepository repo, IAccountLoginHandler login, I
                 }
                 catch (FormatException)
                 {
-                    return Results.BadRequest("Invalid device UUID format.");
+                    deviceGuid = Guid.Empty;
                 }
 
                 devices = await repo.GetAllDisplayNamesForAccountAsync(parsedAccountId, deviceGuid);
             }
             // Proceed with fetching the devices for the user
-
             else
             {
                 devices = await repo.GetAllDisplayNamesForAccountAsync(parsedAccountId, Guid.Empty);

--- a/backend/backend/src/DeviceComponent/Logic/Impl/DeviceHandler.cs
+++ b/backend/backend/src/DeviceComponent/Logic/Impl/DeviceHandler.cs
@@ -67,7 +67,7 @@ public class DeviceHandler(IDeviceRepository repo, IAccountLoginHandler login, I
         return Results.Ok(new DeviceRegisterDto { uuid = deviceUuid });
     }
 
-    private string GetBrowserAndOs(string userAgent)
+    private static string GetBrowserAndOs(string userAgent)
     {
         // Extract OS from the User-Agent string (between parentheses)
         var osRegex = new Regex(@"\(([^)]+)\)");


### PR DESCRIPTION
Beim Aufruf der Registrieren-Funktion wird die DeviceID eines angemeldeten Benutzers nun immer überschrieben.
Darüber hinaus führen malformed UUIDs (z.B. durch händische Manipulation) nicht mehr zu Fehlern bei der Anzeige anderer, bereits registrierter Geräte.