### PR TITLE
Ordner senden als gruppierte Übertragung mit Verzeichnisstruktur

### DIFF
--- a/frontend/src/components/Sharing/DragDropOverlay/DragDropOverlay.tsx
+++ b/frontend/src/components/Sharing/DragDropOverlay/DragDropOverlay.tsx
@@ -1,14 +1,109 @@
 import { useRef, useState } from "react";
 import DragDropIcon from "../../../assets/illustrations/drag_and_drop.svg?react";
 import css from "./DragDropOverlay.module.scss";
+import {
+    FolderFile,
+    ShareSelection,
+} from "../../../types/transfer/ShareSelection";
 
 interface DragDropOverlayProps extends React.HTMLAttributes<HTMLDivElement> {
-    onFilesDropped: (files: FileList) => void;
+    onItemsDropped: (selection: ShareSelection) => void;
     children: React.ReactNode;
 }
 
+/** Reads all entries of a directory; readEntries returns batches (100 in Chromium) until an empty one marks the end. */
+const readAllEntries = async (
+    directory: FileSystemDirectoryEntry
+): Promise<FileSystemEntry[]> => {
+    const reader = directory.createReader();
+    const entries: FileSystemEntry[] = [];
+    for (;;) {
+        const batch = await new Promise<FileSystemEntry[]>(
+            (resolve, reject) => {
+                reader.readEntries(resolve, reject);
+            }
+        );
+        if (batch.length === 0) break;
+        entries.push(...batch);
+    }
+    return entries;
+};
+
+const entryToFile = (entry: FileSystemFileEntry): Promise<File> =>
+    new Promise((resolve, reject) => {
+        entry.file(resolve, reject);
+    });
+
+/** Collects all files below a directory entry; paths include the folder name. */
+async function collectFolderFiles(
+    directory: FileSystemDirectoryEntry,
+    path: string,
+    out: FolderFile[]
+): Promise<void> {
+    for (const entry of await readAllEntries(directory)) {
+        if (entry.isDirectory) {
+            await collectFolderFiles(
+                entry as FileSystemDirectoryEntry,
+                `${path}/${entry.name}`,
+                out
+            );
+        } else if (entry.isFile) {
+            out.push({
+                file: await entryToFile(entry as FileSystemFileEntry),
+                relativePath: `${path}/${entry.name}`,
+            });
+        }
+    }
+}
+
+/**
+ * Turns the DataTransfer of a drop event into a ShareSelection. Dropped
+ * directories are traversed recursively via their filesystem entries.
+ * Entry and file handles are taken synchronously before the first await
+ * because the DataTransfer is only valid during the drop event.
+ */
+async function collectSelection(
+    dataTransfer: DataTransfer
+): Promise<ShareSelection> {
+    const selection: ShareSelection = { files: [], folders: [] };
+
+    const pending = Array.from(dataTransfer.items)
+        .filter(item => item.kind === "file")
+        .map(item => ({
+            entry:
+                typeof item.webkitGetAsEntry === "function"
+                    ? item.webkitGetAsEntry()
+                    : null,
+            file: item.getAsFile(),
+        }));
+
+    if (pending.length === 0) {
+        // Browsers without DataTransferItem entries only expose flat files.
+        selection.files.push(...Array.from(dataTransfer.files));
+        return selection;
+    }
+
+    for (const { entry, file } of pending) {
+        if (entry?.isDirectory) {
+            const files: FolderFile[] = [];
+            await collectFolderFiles(
+                entry as FileSystemDirectoryEntry,
+                entry.name,
+                files
+            );
+            if (files.length > 0) {
+                selection.folders.push({ name: entry.name, files });
+            }
+        } else if (file) {
+            selection.files.push(file);
+        }
+    }
+
+    return selection;
+}
+
 export default function DragDropOverlay({
-    onFilesDropped,
+    onItemsDropped,
     children,
     className,
 }: DragDropOverlayProps) {
@@ -44,13 +139,19 @@ export default function DragDropOverlay({
         dragCounterRef.current = 0;
         setIsDragging(false);
 
-        const droppedFiles = e.dataTransfer.files;
-
-        if (!droppedFiles || droppedFiles.length === 0) {
-            return;
-        }
-
-        onFilesDropped(droppedFiles);
+        void collectSelection(e.dataTransfer)
+            .then(selection => {
+                if (
+                    selection.files.length === 0 &&
+                    selection.folders.length === 0
+                ) {
+                    return;
+                }
+                onItemsDropped(selection);
+            })
+            .catch((err: unknown) => {
+                console.error("Failed to read dropped items:", err);
+            });
     };
 
     return (

--- a/frontend/src/components/Sharing/FileRow/FileRow.module.scss
+++ b/frontend/src/components/Sharing/FileRow/FileRow.module.scss
@@ -42,7 +42,7 @@
     text-overflow: ellipsis;
 }
 
-@mixin iconStyles() {
+@mixin icon-styles() {
     height: calc(var(--font-size-s) * var(--line-height-s));
     vertical-align: top;
 }

--- a/frontend/src/components/Sharing/FileRow/FileRow.module.scss
+++ b/frontend/src/components/Sharing/FileRow/FileRow.module.scss
@@ -36,6 +36,13 @@
     }
 }
 
+// File of an expanded folder, indented below the folder row.
+.nestedName {
+    padding-left: var(--space-24);
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 @mixin iconStyles() {
     height: calc(var(--font-size-s) * var(--line-height-s));
     vertical-align: top;

--- a/frontend/src/components/Sharing/FileRow/FileRow.module.scss
+++ b/frontend/src/components/Sharing/FileRow/FileRow.module.scss
@@ -1,6 +1,6 @@
 .fileRow {
     color: var(--text-muted);
-    font-weight: var(--font-weight-regular);
+    font-weight: var(--font-weight-medium);
     -webkit-backdrop-filter: blur(4px);
     backdrop-filter: blur(4px);
 
@@ -8,8 +8,7 @@
 
     &:hover {
         background-color: var(--secondary-20);
-        font-weight: var(--font-weight-medium);
-        color: var(--text);
+        color: var(--primary);
     }
 
     td {
@@ -36,9 +35,9 @@
     }
 }
 
-// File of an expanded folder, indented below the folder row.
-.nestedName {
-    padding-left: var(--space-24);
+// Name cell content, indented by the folder nesting depth.
+.rowName {
+    padding-left: calc(var(--nesting-depth, 0) * var(--space-24));
     overflow: hidden;
     text-overflow: ellipsis;
 }

--- a/frontend/src/components/Sharing/FileRow/FileRow.tsx
+++ b/frontend/src/components/Sharing/FileRow/FileRow.tsx
@@ -7,78 +7,32 @@ import { usePeerConnectionManager } from "../../../context/connection/PeerConnec
 import Badge from "../../Badge/Badge";
 import Tooltip from "../../Tooltip/Tooltip";
 import { TransferSnapshot } from "../../../services/TransferTracker";
+import {
+    getSizeInHumanReadableFormat,
+    getTimeInHumanReadableFormat,
+    getTransferInfo,
+} from "../transferFormat";
 
 interface FileRowProps {
     transfer: TransferSnapshot;
+    /**
+     * Renders the row indented as part of an expanded folder, showing the
+     * path within the folder instead of the bare file name.
+     */
+    nested?: boolean;
 }
 
-const getSizeInHumanReadableFormat = (size: number): string => {
-    const units = ["B", "KB", "MB", "GB", "TB"];
-    let unitIndex = 0;
-
-    while (size >= 1024 && unitIndex < units.length - 1) {
-        size /= 1024;
-        unitIndex++;
-    }
-
-    return `${size.toFixed(0)} ${units[unitIndex]}`;
-};
-
-const getTimeInHumanReadableFormat = (date: Date): string => {
-    return (
-        ("0" + date.getHours()).slice(-2) +
-        ":" +
-        ("0" + date.getMinutes()).slice(-2) +
-        ":" +
-        ("0" + date.getSeconds()).slice(-2)
-    );
-};
-
-const getSpeedInHumanReadableFormat = (bytesPerSecond: number): string => {
-    const units = ["B/s", "KB/s", "MB/s", "GB/s"];
-    let unitIndex = 0;
-    let speed = bytesPerSecond;
-
-    while (speed >= 1024 && unitIndex < units.length - 1) {
-        speed /= 1024;
-        unitIndex++;
-    }
-
-    return `${speed.toFixed(1)} ${units[unitIndex]}`;
-};
-
-const formatRemainingTime = (seconds: number): string => {
-    if (seconds > 3600) {
-        const hours = Math.floor(seconds / 3600);
-        const minutes = Math.floor((seconds % 3600) / 60);
-        return `${hours}h ${minutes}m`;
-    } else if (seconds > 60) {
-        const minutes = Math.floor(seconds / 60);
-        const rest = Math.ceil(seconds % 60);
-        return `${minutes}m ${rest}s`;
-    }
-    return `${Math.ceil(seconds)}s`;
-};
-
-const getTransferInfo = (transfer: TransferSnapshot): string => {
-    if (transfer.status === "finalizing") {
-        return "Speichern...";
-    }
-    if (transfer.speedBps === null || transfer.speedBps <= 0) {
-        return "Berechne...";
-    }
-
-    const speedText = getSpeedInHumanReadableFormat(transfer.speedBps);
-    if (transfer.etaSeconds === null) {
-        return speedText;
-    }
-    return `${speedText} · ${formatRemainingTime(transfer.etaSeconds)}`;
-};
-
-export default function FileRow({ transfer }: FileRowProps) {
+export default function FileRow({ transfer, nested = false }: FileRowProps) {
     const peerConnectionManager = usePeerConnectionManager();
     const [isOverflowing, setIsOverflowing] = useState(false);
     const nameRef = useRef<HTMLDivElement>(null);
+
+    // Path within the folder, without the folder name shown on the group row.
+    const displayName =
+        nested && transfer.relativePath
+            ? transfer.relativePath.split("/").slice(1).join("/") ||
+              transfer.name
+            : transfer.name;
 
     useEffect(() => {
         // Check if the content overflows
@@ -94,10 +48,11 @@ export default function FileRow({ transfer }: FileRowProps) {
             <td>
                 <div
                     ref={nameRef}
-                    title={isOverflowing ? transfer.name : undefined}
+                    className={nested ? css.nestedName : undefined}
+                    title={isOverflowing ? displayName : undefined}
                 >
                     <StableText
-                        text={transfer.name}
+                        text={displayName}
                         fontWeight="var(--font-weight-medium)"
                     />
                 </div>

--- a/frontend/src/components/Sharing/FileRow/FileRow.tsx
+++ b/frontend/src/components/Sharing/FileRow/FileRow.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useRef, useState } from "react";
-import StableText from "../../StableText/StableText";
+import { CSSProperties, memo, useEffect, useRef, useState } from "react";
 import css from "./FileRow.module.scss";
 import DownloadIcon from "../../../assets/icons8-download.svg?react";
 import UploadIcon from "../../../assets/icons8-upload.svg?react";
@@ -15,24 +14,14 @@ import {
 
 interface FileRowProps {
     transfer: TransferSnapshot;
-    /**
-     * Renders the row indented as part of an expanded folder, showing the
-     * path within the folder instead of the bare file name.
-     */
-    nested?: boolean;
+    /** Nesting level of the row, 0 for a file outside any folder. */
+    depth?: number;
 }
 
-export default function FileRow({ transfer, nested = false }: FileRowProps) {
+function FileRowComponent({ transfer, depth = 0 }: FileRowProps) {
     const peerConnectionManager = usePeerConnectionManager();
     const [isOverflowing, setIsOverflowing] = useState(false);
     const nameRef = useRef<HTMLDivElement>(null);
-
-    // Path within the folder, without the folder name shown on the group row.
-    const displayName =
-        nested && transfer.relativePath
-            ? transfer.relativePath.split("/").slice(1).join("/") ||
-              transfer.name
-            : transfer.name;
 
     useEffect(() => {
         // Check if the content overflows
@@ -48,13 +37,11 @@ export default function FileRow({ transfer, nested = false }: FileRowProps) {
             <td>
                 <div
                     ref={nameRef}
-                    className={nested ? css.nestedName : undefined}
-                    title={isOverflowing ? displayName : undefined}
+                    className={css.rowName}
+                    style={{ "--nesting-depth": depth } as CSSProperties}
+                    title={isOverflowing ? transfer.name : undefined}
                 >
-                    <StableText
-                        text={displayName}
-                        fontWeight="var(--font-weight-medium)"
-                    />
+                    {transfer.name}
                 </div>
             </td>
             <td className={css.progressCell}>
@@ -111,18 +98,12 @@ export default function FileRow({ transfer, nested = false }: FileRowProps) {
                     </div>
                 )}
             </td>
-            <td>
-                <StableText
-                    text={getSizeInHumanReadableFormat(transfer.size)}
-                    fontWeight="var(--font-weight-medium)"
-                />
-            </td>
-            <td>
-                <StableText
-                    text={getTimeInHumanReadableFormat(transfer.startedAt)}
-                    fontWeight="var(--font-weight-medium)"
-                />
-            </td>
+            <td>{getSizeInHumanReadableFormat(transfer.size)}</td>
+            <td>{getTimeInHumanReadableFormat(transfer.startedAt)}</td>
         </tr>
     );
 }
+
+/** Memoized so toggling a folder does not re-render unchanged sibling rows. */
+const FileRow = memo(FileRowComponent);
+export default FileRow;

--- a/frontend/src/components/Sharing/FolderRow/FolderRow.module.scss
+++ b/frontend/src/components/Sharing/FolderRow/FolderRow.module.scss
@@ -1,0 +1,37 @@
+// Expand/collapse toggle spanning folder icon and name.
+.folderToggle {
+    display: flex;
+    align-items: center;
+    gap: var(--space-8);
+    overflow: hidden;
+
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    font: inherit;
+    color: inherit;
+}
+
+.chevron {
+    height: calc(var(--font-size-s) * var(--line-height-s) * 0.6);
+    flex-shrink: 0;
+    fill: currentcolor;
+    transition: transform 0.2s ease;
+}
+
+.chevronOpen {
+    transform: rotate(90deg);
+}
+
+.folderIcon {
+    height: calc(var(--font-size-s) * var(--line-height-s));
+    flex-shrink: 0;
+    fill: currentcolor;
+}
+
+.fileCount {
+    color: var(--text-muted);
+    font-size: var(--font-size-xs);
+    white-space: nowrap;
+}

--- a/frontend/src/components/Sharing/FolderRow/FolderRow.module.scss
+++ b/frontend/src/components/Sharing/FolderRow/FolderRow.module.scss
@@ -8,6 +8,7 @@
     background: none;
     border: none;
     padding: 0;
+    padding-left: calc(var(--nesting-depth, 0) * var(--space-24));
     cursor: pointer;
     font: inherit;
     color: inherit;
@@ -24,10 +25,19 @@
     transform: rotate(90deg);
 }
 
+// Square box matching the other row icons; the wide folder glyph
+// scales down to fit instead of rendering at full row height.
 .folderIcon {
+    width: calc(var(--font-size-s) * var(--line-height-s));
     height: calc(var(--font-size-s) * var(--line-height-s));
     flex-shrink: 0;
     fill: currentcolor;
+}
+
+.folderName {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .fileCount {

--- a/frontend/src/components/Sharing/FolderRow/FolderRow.tsx
+++ b/frontend/src/components/Sharing/FolderRow/FolderRow.tsx
@@ -1,0 +1,166 @@
+import { useState } from "react";
+import StableText from "../../StableText/StableText";
+import rowCss from "../FileRow/FileRow.module.scss";
+import css from "./FolderRow.module.scss";
+import DownloadIcon from "../../../assets/icons8-download.svg?react";
+import UploadIcon from "../../../assets/icons8-upload.svg?react";
+import FolderIcon from "../../../assets/filesystem/icons8-folder.svg?react";
+import ChevronIcon from "../../../assets/actions/icons8-arrow-3.svg?react";
+import { usePeerConnectionManager } from "../../../context/connection/PeerConnectionContext";
+import Badge from "../../Badge/Badge";
+import Tooltip from "../../Tooltip/Tooltip";
+import FileRow from "../FileRow/FileRow";
+import { FolderTransferItem } from "../groupTransfers";
+import {
+    getSizeInHumanReadableFormat,
+    getTimeInHumanReadableFormat,
+    getTransferInfo,
+} from "../transferFormat";
+
+interface FolderRowProps {
+    folder: FolderTransferItem;
+}
+
+/**
+ * One folder transfer in the sharing table: a group row with aggregated
+ * size, progress and status, expandable to the contained file rows.
+ */
+export default function FolderRow({ folder }: FolderRowProps) {
+    const peerConnectionManager = usePeerConnectionManager();
+    const [expanded, setExpanded] = useState(false);
+
+    const files = folder.files;
+    const direction = files[0].direction;
+
+    const totalSize = files.reduce((sum, file) => sum + file.size, 0);
+    const totalBytes = files.reduce(
+        (sum, file) => sum + file.bytesTransferred,
+        0
+    );
+    const progress = totalSize > 0 ? Math.min(totalBytes / totalSize, 1) : 0;
+    const startedAt = files.reduce(
+        (earliest, file) =>
+            file.startedAt < earliest ? file.startedAt : earliest,
+        files[0].startedAt
+    );
+
+    const allDone = files.every(file => file.status === "done");
+    const anyFailed = files.some(file => file.status === "failed");
+    const anyFinalizing = files.some(file => file.status === "finalizing");
+
+    const speedBps = files.reduce<number | null>(
+        (sum, file) =>
+            file.speedBps !== null ? (sum ?? 0) + file.speedBps : sum,
+        null
+    );
+    const etaSeconds =
+        speedBps !== null && speedBps > 0
+            ? Math.max(totalSize - totalBytes, 0) / speedBps
+            : null;
+
+    return (
+        <>
+            <tr className={rowCss.fileRow}>
+                <td>
+                    <button
+                        type="button"
+                        className={css.folderToggle}
+                        onClick={() => setExpanded(value => !value)}
+                        aria-expanded={expanded}
+                    >
+                        <ChevronIcon
+                            className={`${css.chevron} ${expanded ? css.chevronOpen : ""}`}
+                        />
+                        <FolderIcon className={css.folderIcon} />
+                        <StableText
+                            text={folder.name}
+                            fontWeight="var(--font-weight-medium)"
+                        />
+                        <span className={css.fileCount}>
+                            {files.length === 1
+                                ? "1 Datei"
+                                : `${files.length} Dateien`}
+                        </span>
+                    </button>
+                </td>
+                <td className={rowCss.progressCell}>
+                    {direction === "up" ? (
+                        <UploadIcon className={rowCss.uploadIcon} />
+                    ) : (
+                        <DownloadIcon className={rowCss.downloadIcon} />
+                    )}
+
+                    {allDone ? (
+                        <>
+                            <Badge color_scheme="success" size={"m"}>
+                                Fertig!
+                            </Badge>
+                            {direction === "down" && (
+                                <Tooltip
+                                    content="Klicken, um den Ordner zu speichern"
+                                    position="top"
+                                >
+                                    <Badge
+                                        size="s"
+                                        color_scheme="neutral"
+                                        clickable
+                                        onClick={() => {
+                                            void peerConnectionManager.saveFolder(
+                                                folder.folderId
+                                            );
+                                        }}
+                                    >
+                                        SPEICHERN
+                                    </Badge>
+                                </Tooltip>
+                            )}
+                        </>
+                    ) : anyFailed ? (
+                        <Badge color_scheme="neutral" size={"m"}>
+                            Fehlgeschlagen
+                        </Badge>
+                    ) : (
+                        <div className={rowCss.progressContainer}>
+                            <div className={rowCss.progressInfo}>
+                                <span>{(progress * 100).toFixed(2)} %</span>
+
+                                <span>
+                                    {getTransferInfo({
+                                        status: anyFinalizing
+                                            ? "finalizing"
+                                            : "active",
+                                        speedBps,
+                                        etaSeconds,
+                                    })}
+                                </span>
+                            </div>
+
+                            <progress
+                                className={rowCss.progressBar}
+                                value={progress}
+                                max={1}
+                            />
+                        </div>
+                    )}
+                </td>
+                <td>
+                    <StableText
+                        text={getSizeInHumanReadableFormat(totalSize)}
+                        fontWeight="var(--font-weight-medium)"
+                    />
+                </td>
+                <td>
+                    <StableText
+                        text={getTimeInHumanReadableFormat(startedAt)}
+                        fontWeight="var(--font-weight-medium)"
+                    />
+                </td>
+            </tr>
+
+            {expanded &&
+                files.map(transfer => (
+                    <FileRow key={transfer.uuid} transfer={transfer} nested />
+                ))}
+        </>
+    );
+}

--- a/frontend/src/components/Sharing/FolderRow/FolderRow.tsx
+++ b/frontend/src/components/Sharing/FolderRow/FolderRow.tsx
@@ -1,5 +1,4 @@
-import { useState } from "react";
-import StableText from "../../StableText/StableText";
+import { CSSProperties, memo, useState } from "react";
 import rowCss from "../FileRow/FileRow.module.scss";
 import css from "./FolderRow.module.scss";
 import DownloadIcon from "../../../assets/icons8-download.svg?react";
@@ -10,7 +9,7 @@ import { usePeerConnectionManager } from "../../../context/connection/PeerConnec
 import Badge from "../../Badge/Badge";
 import Tooltip from "../../Tooltip/Tooltip";
 import FileRow from "../FileRow/FileRow";
-import { FolderTransferItem } from "../groupTransfers";
+import { FolderNode } from "../groupTransfers";
 import {
     getSizeInHumanReadableFormat,
     getTimeInHumanReadableFormat,
@@ -18,37 +17,45 @@ import {
 } from "../transferFormat";
 
 interface FolderRowProps {
-    folder: FolderTransferItem;
+    folder: FolderNode;
+    /**
+     * Identifier of the whole folder transfer. Only set on the top-level
+     * row, where it enables saving the received folder.
+     */
+    folderId?: string;
+    /** Nesting level of the row, 0 for a top-level folder. */
+    depth?: number;
 }
 
 /**
- * One folder transfer in the sharing table: a group row with aggregated
- * size, progress and status, expandable to the contained file rows.
+ * One folder level in the sharing table: a group row with aggregated size,
+ * progress and status of its subtree, expandable to the contained subfolder
+ * and file rows.
  */
-export default function FolderRow({ folder }: FolderRowProps) {
+function FolderRowComponent({ folder, folderId, depth = 0 }: FolderRowProps) {
     const peerConnectionManager = usePeerConnectionManager();
     const [expanded, setExpanded] = useState(false);
 
-    const files = folder.files;
-    const direction = files[0].direction;
+    const transfers = folder.transfers;
+    const direction = transfers[0].direction;
 
-    const totalSize = files.reduce((sum, file) => sum + file.size, 0);
-    const totalBytes = files.reduce(
+    const totalSize = transfers.reduce((sum, file) => sum + file.size, 0);
+    const totalBytes = transfers.reduce(
         (sum, file) => sum + file.bytesTransferred,
         0
     );
     const progress = totalSize > 0 ? Math.min(totalBytes / totalSize, 1) : 0;
-    const startedAt = files.reduce(
+    const startedAt = transfers.reduce(
         (earliest, file) =>
             file.startedAt < earliest ? file.startedAt : earliest,
-        files[0].startedAt
+        transfers[0].startedAt
     );
 
-    const allDone = files.every(file => file.status === "done");
-    const anyFailed = files.some(file => file.status === "failed");
-    const anyFinalizing = files.some(file => file.status === "finalizing");
+    const allDone = transfers.every(file => file.status === "done");
+    const anyFailed = transfers.some(file => file.status === "failed");
+    const anyFinalizing = transfers.some(file => file.status === "finalizing");
 
-    const speedBps = files.reduce<number | null>(
+    const speedBps = transfers.reduce<number | null>(
         (sum, file) =>
             file.speedBps !== null ? (sum ?? 0) + file.speedBps : sum,
         null
@@ -65,6 +72,7 @@ export default function FolderRow({ folder }: FolderRowProps) {
                     <button
                         type="button"
                         className={css.folderToggle}
+                        style={{ "--nesting-depth": depth } as CSSProperties}
                         onClick={() => setExpanded(value => !value)}
                         aria-expanded={expanded}
                     >
@@ -72,14 +80,11 @@ export default function FolderRow({ folder }: FolderRowProps) {
                             className={`${css.chevron} ${expanded ? css.chevronOpen : ""}`}
                         />
                         <FolderIcon className={css.folderIcon} />
-                        <StableText
-                            text={folder.name}
-                            fontWeight="var(--font-weight-medium)"
-                        />
+                        <span className={css.folderName}>{folder.name}</span>
                         <span className={css.fileCount}>
-                            {files.length === 1
+                            {transfers.length === 1
                                 ? "1 Datei"
-                                : `${files.length} Dateien`}
+                                : `${transfers.length} Dateien`}
                         </span>
                     </button>
                 </td>
@@ -95,7 +100,7 @@ export default function FolderRow({ folder }: FolderRowProps) {
                             <Badge color_scheme="success" size={"m"}>
                                 Fertig!
                             </Badge>
-                            {direction === "down" && (
+                            {direction === "down" && folderId && (
                                 <Tooltip
                                     content="Klicken, um den Ordner zu speichern"
                                     position="top"
@@ -106,7 +111,7 @@ export default function FolderRow({ folder }: FolderRowProps) {
                                         clickable
                                         onClick={() => {
                                             void peerConnectionManager.saveFolder(
-                                                folder.folderId
+                                                folderId
                                             );
                                         }}
                                     >
@@ -143,24 +148,32 @@ export default function FolderRow({ folder }: FolderRowProps) {
                         </div>
                     )}
                 </td>
-                <td>
-                    <StableText
-                        text={getSizeInHumanReadableFormat(totalSize)}
-                        fontWeight="var(--font-weight-medium)"
-                    />
-                </td>
-                <td>
-                    <StableText
-                        text={getTimeInHumanReadableFormat(startedAt)}
-                        fontWeight="var(--font-weight-medium)"
-                    />
-                </td>
+                <td>{getSizeInHumanReadableFormat(totalSize)}</td>
+                <td>{getTimeInHumanReadableFormat(startedAt)}</td>
             </tr>
 
-            {expanded &&
-                files.map(transfer => (
-                    <FileRow key={transfer.uuid} transfer={transfer} nested />
-                ))}
+            {expanded && (
+                <>
+                    {folder.subfolders.map(subfolder => (
+                        <FolderRow
+                            key={subfolder.id}
+                            folder={subfolder}
+                            depth={depth + 1}
+                        />
+                    ))}
+                    {folder.files.map(transfer => (
+                        <FileRow
+                            key={transfer.uuid}
+                            transfer={transfer}
+                            depth={depth + 1}
+                        />
+                    ))}
+                </>
+            )}
         </>
     );
 }
+
+/** Memoized so toggling a folder does not re-render unchanged sibling rows. */
+const FolderRow = memo(FolderRowComponent);
+export default FolderRow;

--- a/frontend/src/components/Sharing/Sharing.module.scss
+++ b/frontend/src/components/Sharing/Sharing.module.scss
@@ -23,7 +23,10 @@
 }
 
 .uploadButtons {
-    display: flex;
+    // Equal columns so both upload buttons get the same size.
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: 1fr;
     gap: var(--gap);
 }
 

--- a/frontend/src/components/Sharing/Sharing.tsx
+++ b/frontend/src/components/Sharing/Sharing.tsx
@@ -52,7 +52,7 @@ export default function Sharing() {
                             <ImageFileIcon className={css.fileIcon2} />
                             <ZipFileIcon className={css.fileIcon3} />
                         </div>
-                        Dateien hinzufügen
+                        Datei teilen
                     </Button>
                     <input
                         type="file"
@@ -76,7 +76,7 @@ export default function Sharing() {
                             <FolderIcon className={css.folderClosed} />
                             <FolderOpenIcon className={css.folderOpen} />
                         </div>
-                        Ordner hinzufügen
+                        Ordner teilen
                     </Button>
                 </div>
 

--- a/frontend/src/components/Sharing/Sharing.tsx
+++ b/frontend/src/components/Sharing/Sharing.tsx
@@ -7,7 +7,7 @@ import FolderIcon from "../../assets/filesystem/icons8-folder.svg?react";
 import FolderOpenIcon from "../../assets/filesystem/icons8-folder-2.svg?react";
 import { useDeviceHeartbeat } from "../../hooks/useDeviceHeartbeat";
 import { DeviceStatus } from "../../types/device/DeviceStatus";
-import { useRef } from "react";
+import { useMemo, useRef } from "react";
 import RemoteTokenDisplay from "../RemoteTokenDisplay/RemoteTokenDisplay";
 import FileRow from "./FileRow/FileRow";
 import FolderRow from "./FolderRow/FolderRow";
@@ -26,7 +26,7 @@ export default function Sharing() {
         useFileTransfer();
     const { closeConnection } = useConnectionLifecycle();
 
-    const transferItems = groupTransfers(transfers);
+    const transferItems = useMemo(() => groupTransfers(transfers), [transfers]);
 
     return (
         <div className={css.sharingContainer}>
@@ -114,7 +114,11 @@ export default function Sharing() {
                     <tbody>
                         {transferItems.map(item =>
                             item.kind === "folder" ? (
-                                <FolderRow key={item.folderId} folder={item} />
+                                <FolderRow
+                                    key={item.folderId}
+                                    folder={item}
+                                    folderId={item.folderId}
+                                />
                             ) : (
                                 <FileRow
                                     key={item.transfer.uuid}

--- a/frontend/src/components/Sharing/Sharing.tsx
+++ b/frontend/src/components/Sharing/Sharing.tsx
@@ -10,9 +10,11 @@ import { DeviceStatus } from "../../types/device/DeviceStatus";
 import { useRef } from "react";
 import RemoteTokenDisplay from "../RemoteTokenDisplay/RemoteTokenDisplay";
 import FileRow from "./FileRow/FileRow";
+import FolderRow from "./FolderRow/FolderRow";
 import DragDropOverlay from "./DragDropOverlay/DragDropOverlay";
 import useFileTransfer from "../../hooks/useFileTransfer";
 import useConnectionLifecycle from "../../hooks/useConnectionLifecycle";
+import { groupTransfers } from "./groupTransfers";
 
 export default function Sharing() {
     useDeviceHeartbeat({ status: DeviceStatus.BUSY });
@@ -20,8 +22,11 @@ export default function Sharing() {
     const fileInputRef = useRef<HTMLInputElement>(null);
     const folderInputRef = useRef<HTMLInputElement>(null);
 
-    const { transfers, handleFileInputChange, sendFiles } = useFileTransfer();
+    const { transfers, handleFileInputChange, sendSelection } =
+        useFileTransfer();
     const { closeConnection } = useConnectionLifecycle();
+
+    const transferItems = groupTransfers(transfers);
 
     return (
         <div className={css.sharingContainer}>
@@ -47,7 +52,7 @@ export default function Sharing() {
                             <ImageFileIcon className={css.fileIcon2} />
                             <ZipFileIcon className={css.fileIcon3} />
                         </div>
-                        Datei teilen
+                        Dateien hinzufügen
                     </Button>
                     <input
                         type="file"
@@ -71,7 +76,7 @@ export default function Sharing() {
                             <FolderIcon className={css.folderClosed} />
                             <FolderOpenIcon className={css.folderOpen} />
                         </div>
-                        Ordner teilen
+                        Ordner hinzufügen
                     </Button>
                 </div>
 
@@ -93,7 +98,7 @@ export default function Sharing() {
             </div>
 
             <DragDropOverlay
-                onFilesDropped={sendFiles}
+                onItemsDropped={sendSelection}
                 className={css.dragDropOverlay}
             >
                 <table className={css.table}>
@@ -107,9 +112,16 @@ export default function Sharing() {
                     </thead>
 
                     <tbody>
-                        {transfers.map(transfer => (
-                            <FileRow key={transfer.uuid} transfer={transfer} />
-                        ))}
+                        {transferItems.map(item =>
+                            item.kind === "folder" ? (
+                                <FolderRow key={item.folderId} folder={item} />
+                            ) : (
+                                <FileRow
+                                    key={item.transfer.uuid}
+                                    transfer={item.transfer}
+                                />
+                            )
+                        )}
                     </tbody>
                 </table>
             </DragDropOverlay>

--- a/frontend/src/components/Sharing/groupTransfers.ts
+++ b/frontend/src/components/Sharing/groupTransfers.ts
@@ -5,25 +5,40 @@ export interface FileTransferItem {
     transfer: TransferSnapshot;
 }
 
-export interface FolderTransferItem {
+/**
+ * One folder level of a folder transfer. Subfolder nodes are derived from
+ * the relativePath segments of the contained files.
+ */
+export interface FolderNode {
+    /** Stable key: the folderId extended by the path of this level. */
+    id: string;
+    name: string;
+    /** Every transfer in this folder's subtree, used for aggregation. */
+    transfers: TransferSnapshot[];
+    /** Files directly inside this folder level. */
+    files: TransferSnapshot[];
+    subfolders: FolderNode[];
+}
+
+export interface FolderTransferItem extends FolderNode {
     kind: "folder";
     folderId: string;
-    name: string;
-    files: TransferSnapshot[];
 }
 
 export type TransferListItem = FileTransferItem | FolderTransferItem;
 
 /**
  * Groups transfer snapshots for the sharing table: files that share a
- * folderId become one folder item, everything else stays an individual file
- * item. Order follows the first appearance of each item.
+ * folderId become one folder item with subfolder nodes derived from their
+ * relative paths, everything else stays an individual file item. Order
+ * follows the first appearance of each item.
  */
 export function groupTransfers(
     transfers: TransferSnapshot[]
 ): TransferListItem[] {
     const items: TransferListItem[] = [];
     const folderItems = new Map<string, FolderTransferItem>();
+    const nodesById = new Map<string, FolderNode>();
 
     for (const transfer of transfers) {
         if (!transfer.folderId) {
@@ -36,14 +51,48 @@ export function groupTransfers(
             folder = {
                 kind: "folder",
                 folderId: transfer.folderId,
+                id: transfer.folderId,
                 name: transfer.folderName ?? transfer.name,
+                transfers: [],
                 files: [],
+                subfolders: [],
             };
             folderItems.set(transfer.folderId, folder);
             items.push(folder);
         }
-        folder.files.push(transfer);
+
+        insertTransfer(folder, transfer, nodesById);
     }
 
     return items;
+}
+
+/**
+ * Adds a transfer below its top-level folder. The relativePath segments
+ * between the folder name and the file name become nested folder nodes.
+ */
+function insertTransfer(
+    folder: FolderTransferItem,
+    transfer: TransferSnapshot,
+    nodesById: Map<string, FolderNode>
+) {
+    // First segment is the top-level folder, last segment the file name.
+    const subfolderNames = transfer.relativePath?.split("/").slice(1, -1) ?? [];
+
+    let node: FolderNode = folder;
+    node.transfers.push(transfer);
+
+    for (const name of subfolderNames) {
+        const id = `${node.id}/${name}`;
+        let child = nodesById.get(id);
+        if (!child) {
+            child = { id, name, transfers: [], files: [], subfolders: [] };
+            nodesById.set(id, child);
+            node.subfolders.push(child);
+        }
+        child.transfers.push(transfer);
+        node = child;
+    }
+
+    node.files.push(transfer);
 }

--- a/frontend/src/components/Sharing/groupTransfers.ts
+++ b/frontend/src/components/Sharing/groupTransfers.ts
@@ -1,0 +1,49 @@
+import { TransferSnapshot } from "../../services/TransferTracker";
+
+export interface FileTransferItem {
+    kind: "file";
+    transfer: TransferSnapshot;
+}
+
+export interface FolderTransferItem {
+    kind: "folder";
+    folderId: string;
+    name: string;
+    files: TransferSnapshot[];
+}
+
+export type TransferListItem = FileTransferItem | FolderTransferItem;
+
+/**
+ * Groups transfer snapshots for the sharing table: files that share a
+ * folderId become one folder item, everything else stays an individual file
+ * item. Order follows the first appearance of each item.
+ */
+export function groupTransfers(
+    transfers: TransferSnapshot[]
+): TransferListItem[] {
+    const items: TransferListItem[] = [];
+    const folderItems = new Map<string, FolderTransferItem>();
+
+    for (const transfer of transfers) {
+        if (!transfer.folderId) {
+            items.push({ kind: "file", transfer });
+            continue;
+        }
+
+        let folder = folderItems.get(transfer.folderId);
+        if (!folder) {
+            folder = {
+                kind: "folder",
+                folderId: transfer.folderId,
+                name: transfer.folderName ?? transfer.name,
+                files: [],
+            };
+            folderItems.set(transfer.folderId, folder);
+            items.push(folder);
+        }
+        folder.files.push(transfer);
+    }
+
+    return items;
+}

--- a/frontend/src/components/Sharing/transferFormat.ts
+++ b/frontend/src/components/Sharing/transferFormat.ts
@@ -1,0 +1,71 @@
+/** Formatting helpers shared by the file and folder rows of the sharing table. */
+
+import { TransferStatus } from "../../services/TransferTracker";
+
+export const getSizeInHumanReadableFormat = (size: number): string => {
+    const units = ["B", "KB", "MB", "GB", "TB"];
+    let unitIndex = 0;
+
+    while (size >= 1024 && unitIndex < units.length - 1) {
+        size /= 1024;
+        unitIndex++;
+    }
+
+    return `${size.toFixed(0)} ${units[unitIndex]}`;
+};
+
+export const getTimeInHumanReadableFormat = (date: Date): string => {
+    return (
+        ("0" + date.getHours()).slice(-2) +
+        ":" +
+        ("0" + date.getMinutes()).slice(-2) +
+        ":" +
+        ("0" + date.getSeconds()).slice(-2)
+    );
+};
+
+const getSpeedInHumanReadableFormat = (bytesPerSecond: number): string => {
+    const units = ["B/s", "KB/s", "MB/s", "GB/s"];
+    let unitIndex = 0;
+    let speed = bytesPerSecond;
+
+    while (speed >= 1024 && unitIndex < units.length - 1) {
+        speed /= 1024;
+        unitIndex++;
+    }
+
+    return `${speed.toFixed(1)} ${units[unitIndex]}`;
+};
+
+const formatRemainingTime = (seconds: number): string => {
+    if (seconds > 3600) {
+        const hours = Math.floor(seconds / 3600);
+        const minutes = Math.floor((seconds % 3600) / 60);
+        return `${hours}h ${minutes}m`;
+    } else if (seconds > 60) {
+        const minutes = Math.floor(seconds / 60);
+        const rest = Math.ceil(seconds % 60);
+        return `${minutes}m ${rest}s`;
+    }
+    return `${Math.ceil(seconds)}s`;
+};
+
+/** Speed and remaining time line shown next to a running progress bar. */
+export const getTransferInfo = (transfer: {
+    status: TransferStatus;
+    speedBps: number | null;
+    etaSeconds: number | null;
+}): string => {
+    if (transfer.status === "finalizing") {
+        return "Speichern...";
+    }
+    if (transfer.speedBps === null || transfer.speedBps <= 0) {
+        return "Berechne...";
+    }
+
+    const speedText = getSpeedInHumanReadableFormat(transfer.speedBps);
+    if (transfer.etaSeconds === null) {
+        return speedText;
+    }
+    return `${speedText} · ${formatRemainingTime(transfer.etaSeconds)}`;
+};

--- a/frontend/src/hooks/useFileTransfer.tsx
+++ b/frontend/src/hooks/useFileTransfer.tsx
@@ -1,12 +1,14 @@
 import { useSyncExternalStore } from "react";
 import { usePeerConnectionManager } from "../context/connection/PeerConnectionContext";
 import { TransferSnapshot } from "../services/TransferTracker";
+import { ShareSelection, SharedFolder } from "../types/transfer/ShareSelection";
 
 /**
  * Custom hook for managing file transfers between peers.
  *
  * Exposes the transfer snapshots from the TransferTracker (the single source
- * of truth for progress, speed and status) and functions to send files.
+ * of truth for progress, speed and status) and functions to send files and
+ * folders.
  */
 export default function useFileTransfer() {
     const peerConnectionManager = usePeerConnectionManager();
@@ -18,8 +20,9 @@ export default function useFileTransfer() {
     );
 
     /**
-     * Handles file input change events (e.g., from file picker dialogs).
-     * Processes the selected files and initiates upload.
+     * Handles change events of both the file and the folder input.
+     * Files picked via the folder input carry a webkitRelativePath and are
+     * grouped into folder transfers; plain files are sent individually.
      * Resets the input to allow re-selecting the same file.
      *
      * @param {React.ChangeEvent<HTMLInputElement>} event - The input change event
@@ -39,14 +42,70 @@ export default function useFileTransfer() {
     };
 
     /**
-     * Sends multiple files to the connected peer.
-     * Creates a unique UUID for each file; the transfer tracker picks the
-     * transfer up as soon as sending starts.
+     * Sends multiple files to the connected peer. Files with a
+     * webkitRelativePath (folder picker) are grouped by their top-level
+     * folder and sent as folder transfers; all other files are sent
+     * individually.
      *
-     * @param {FileList} filesList - The list of files to send
+     * @param {FileList | File[]} filesList - The list of files to send
      */
-    const sendFiles = (filesList: FileList) => {
+    const sendFiles = (filesList: FileList | File[]) => {
+        const files: File[] = [];
+        const folders = new Map<string, SharedFolder>();
+
         for (const file of filesList) {
+            const relativePath = file.webkitRelativePath;
+            if (!relativePath) {
+                files.push(file);
+                continue;
+            }
+
+            const folderName = relativePath.split("/")[0];
+            let folder = folders.get(folderName);
+            if (!folder) {
+                folder = { name: folderName, files: [] };
+                folders.set(folderName, folder);
+            }
+            folder.files.push({ file, relativePath });
+        }
+
+        sendSelection({ files, folders: Array.from(folders.values()) });
+    };
+
+    /**
+     * Sends a selection of loose files and whole folders (e.g. from drag
+     * and drop) to the connected peer.
+     */
+    const sendSelection = (selection: ShareSelection) => {
+        selection.files.forEach(sendSingleFile);
+        selection.folders.forEach(sendFolder);
+    };
+
+    const sendSingleFile = (file: File) => {
+        const uuid = crypto.randomUUID();
+
+        // Useful for development/testing without connection
+        if (!peerConnectionManager.getConnection()) {
+            transferTracker.start(uuid, {
+                name: file.name,
+                size: file.size,
+                direction: "up",
+            });
+            return;
+        }
+
+        peerConnectionManager.sendFile(file, uuid);
+    };
+
+    /**
+     * Sends all files of a folder. A shared folder ID ties the individual
+     * file transfers together so both peers can show the folder as one
+     * grouped entry.
+     */
+    const sendFolder = (folder: SharedFolder) => {
+        const folderId = crypto.randomUUID();
+
+        for (const { file, relativePath } of folder.files) {
             const uuid = crypto.randomUUID();
 
             // Useful for development/testing without connection
@@ -55,11 +114,16 @@ export default function useFileTransfer() {
                     name: file.name,
                     size: file.size,
                     direction: "up",
+                    folderId,
+                    relativePath,
                 });
                 continue;
             }
 
-            peerConnectionManager.sendFile(file, uuid);
+            peerConnectionManager.sendFile(file, uuid, {
+                folderId,
+                relativePath,
+            });
         }
     };
 
@@ -67,5 +131,6 @@ export default function useFileTransfer() {
         transfers,
         handleFileInputChange,
         sendFiles,
+        sendSelection,
     };
 }

--- a/frontend/src/services/PeerConnectionManager.ts
+++ b/frontend/src/services/PeerConnectionManager.ts
@@ -1,5 +1,5 @@
 import { assert } from "../util/Assert";
-import { WebRTCConnection } from "./WebRTCConnection";
+import { FolderInfo, WebRTCConnection } from "./WebRTCConnection";
 import {
     MessageHandler,
     WebSocketService,
@@ -391,10 +391,12 @@ export class PeerConnectionManager {
      * Sends a file to the remote peer using the underlying WebRTCConnection.
      * Throws if no active connection exists.
      * @param file The file to send.
+     * @param folder Folder membership when the file is part of a folder
+     * transfer.
      */
-    public sendFile(file: File, uuid: string) {
+    public sendFile(file: File, uuid: string, folder?: FolderInfo) {
         assert(this.webrtcConnection, "No active connection to send file.");
-        this.webrtcConnection.sendFileOverDataChannel(file, uuid);
+        this.webrtcConnection.sendFileOverDataChannel(file, uuid, folder);
     }
 
     /**
@@ -408,5 +410,19 @@ export class PeerConnectionManager {
             return false;
         }
         return this.webrtcConnection.redownloadFile(uuid);
+    }
+
+    /**
+     * Saves all completed files of a received folder transfer, either into a
+     * user-picked directory (Chromium) or as individual downloads.
+     * @param folderId The folder ID of the transfer to save.
+     * @returns true if saving was started, false otherwise.
+     */
+    public async saveFolder(folderId: string): Promise<boolean> {
+        if (!this.webrtcConnection) {
+            this.log("No active connection to save folder.");
+            return false;
+        }
+        return this.webrtcConnection.saveFolder(folderId);
     }
 }

--- a/frontend/src/services/TransferTracker.ts
+++ b/frontend/src/services/TransferTracker.ts
@@ -26,6 +26,12 @@ export interface TransferSnapshot {
     name: string;
     size: number;
     direction: TransferDirection;
+    /** Groups files that belong to the same folder transfer. */
+    folderId?: string;
+    /** Folder display name, derived from the first segment of relativePath. */
+    folderName?: string;
+    /** Path within the shared folder, including the folder name. */
+    relativePath?: string;
     startedAt: Date;
     bytesTransferred: number;
     /** 0..1 */
@@ -42,6 +48,8 @@ interface TransferEntry {
     name: string;
     size: number;
     direction: TransferDirection;
+    folderId?: string;
+    relativePath?: string;
     startedAt: Date;
     bytesTransferred: number;
     status: TransferStatus;
@@ -65,13 +73,21 @@ export class TransferTracker {
 
     public start(
         uuid: string,
-        info: { name: string; size: number; direction: TransferDirection }
+        info: {
+            name: string;
+            size: number;
+            direction: TransferDirection;
+            folderId?: string;
+            relativePath?: string;
+        }
     ) {
         this.entries.set(uuid, {
             uuid,
             name: info.name,
             size: info.size,
             direction: info.direction,
+            folderId: info.folderId,
+            relativePath: info.relativePath,
             startedAt: new Date(),
             bytesTransferred: 0,
             status: "waiting",
@@ -157,6 +173,9 @@ export class TransferTracker {
             name: entry.name,
             size: entry.size,
             direction: entry.direction,
+            folderId: entry.folderId,
+            folderName: entry.relativePath?.split("/")[0],
+            relativePath: entry.relativePath,
             startedAt: entry.startedAt,
             bytesTransferred: entry.bytesTransferred,
             progress:

--- a/frontend/src/services/WebRTCConnection.ts
+++ b/frontend/src/services/WebRTCConnection.ts
@@ -32,6 +32,19 @@ interface FileMeta {
     chunkCount: number;
     /** Payload bytes per full chunk; positions writes of unordered chunks. */
     chunkSize: number;
+    /**
+     * Path within a shared folder, including the folder name as first
+     * segment. Absent for single-file transfers.
+     */
+    relativePath?: string;
+    /** Groups files of the same folder transfer. Absent for single files. */
+    folderId?: string;
+}
+
+/** Folder membership of an outgoing file. */
+export interface FolderInfo {
+    folderId: string;
+    relativePath: string;
 }
 
 /** Reassembly state of one incoming file transfer. */
@@ -62,10 +75,15 @@ export class WebRTCConnection {
     // Reassembly state of incoming transfers, keyed by file UUID (= channel label).
     private readonly incomingTransfers: Map<string, ReceiveState> = new Map();
 
-    // Store completed downloads for re-download capability
+    // Store completed downloads for re-download and folder saving
     private readonly completedDownloads: Map<
         string, // File UUID
-        { blob: Blob; filename: string }
+        {
+            blob: Blob;
+            filename: string;
+            relativePath?: string;
+            folderId?: string;
+        }
     > = new Map();
 
     // Perfect Negotiation Pattern variables
@@ -124,8 +142,15 @@ export class WebRTCConnection {
      * once the buffer drains to LOW_WATER_MARK.
      *
      * @param file The file to be sent to the remote peer.
+     * @param folder Folder membership when the file is part of a folder
+     * transfer; carried in the metadata message so the receiver can rebuild
+     * the folder structure.
      */
-    public sendFileOverDataChannel(file: File, uuid: string) {
+    public sendFileOverDataChannel(
+        file: File,
+        uuid: string,
+        folder?: FolderInfo
+    ) {
         this.log(
             `File is ${[
                 file.name,
@@ -139,6 +164,8 @@ export class WebRTCConnection {
             name: file.name,
             size: file.size,
             direction: "up",
+            folderId: folder?.folderId,
+            relativePath: folder?.relativePath,
         });
 
         const dataChannel = this.peerConnection.createDataChannel(uuid, {
@@ -193,6 +220,8 @@ export class WebRTCConnection {
                     uuid: uuid,
                     chunkCount: chunkCount,
                     chunkSize: payloadSize,
+                    relativePath: folder?.relativePath,
+                    folderId: folder?.folderId,
                 })
             );
 
@@ -342,6 +371,8 @@ export class WebRTCConnection {
                     name: state.fileMeta.name,
                     size: state.fileMeta.size,
                     direction: "down",
+                    folderId: state.fileMeta.folderId,
+                    relativePath: state.fileMeta.relativePath,
                 });
 
                 state.earlyChunks.forEach(handleSequencedChunk);
@@ -430,13 +461,29 @@ export class WebRTCConnection {
 
         this.transferTracker.setStatus(uuid, "done");
 
-        // Store the blob for potential re-download
+        // Store the blob for potential re-download and folder saving
         if (state.fileMeta?.uuid) {
             this.completedDownloads.set(state.fileMeta.uuid, {
                 blob,
                 filename,
+                relativePath: state.fileMeta.relativePath,
+                folderId: state.fileMeta.folderId,
             });
             this.incomingTransfers.delete(state.fileMeta.uuid);
+        }
+
+        // Files of a folder transfer are saved together via saveFolder()
+        // when the browser has a directory picker; individual downloads
+        // would land flat in the download folder.
+        if (
+            state.fileMeta?.folderId &&
+            WebRTCConnection.isDirectoryPickerSupported()
+        ) {
+            this.log(
+                "File ready for folder save with TransferID:",
+                state.fileMeta.uuid
+            );
+            return;
         }
 
         // Yield to the event loop so the UI can render the completed state
@@ -601,6 +648,70 @@ export class WebRTCConnection {
         return true;
     }
 
+    /** True when the browser exposes the File System Access directory picker. */
+    public static isDirectoryPickerSupported(): boolean {
+        return (
+            typeof window !== "undefined" &&
+            typeof window.showDirectoryPicker === "function"
+        );
+    }
+
+    /**
+     * Saves all completed files of a folder transfer.
+     *
+     * With the File System Access API (Chromium) the user picks a target
+     * directory and the folder structure is recreated inside it. Without it
+     * each file is downloaded individually via the regular download queue.
+     *
+     * @param folderId The folder ID of the transfer to save.
+     * @returns true if saving was started, false when no completed files
+     * exist for the folder or the user dismissed the directory picker.
+     */
+    public async saveFolder(folderId: string): Promise<boolean> {
+        const entries = Array.from(this.completedDownloads.values()).filter(
+            entry => entry.folderId === folderId
+        );
+        if (entries.length === 0) {
+            this.log("No completed files for folder:", folderId);
+            return false;
+        }
+
+        if (!WebRTCConnection.isDirectoryPickerSupported()) {
+            entries.forEach(entry =>
+                this.triggerDownload(entry.blob, entry.filename)
+            );
+            return true;
+        }
+
+        const [directory, err] = await errorAsValue(
+            window.showDirectoryPicker!({ mode: "readwrite" })
+        );
+        if (err) {
+            // Usually the user closed the picker.
+            this.log("Directory picker dismissed:", err);
+            return false;
+        }
+
+        for (const entry of entries) {
+            const [, writeErr] = await errorAsValue(
+                writeFileToDirectory(
+                    directory,
+                    entry.relativePath ?? entry.filename,
+                    entry.blob
+                )
+            );
+            if (writeErr) {
+                console.error(
+                    "Failed to save file into directory:",
+                    entry.relativePath ?? entry.filename,
+                    writeErr
+                );
+                return false;
+            }
+        }
+        return true;
+    }
+
     public closeConnection() {
         this.incomingTransfers.forEach(state => {
             void state.opfsWriter?.abort();
@@ -674,6 +785,31 @@ export class WebRTCConnection {
             observable.unsubscribeAll();
         });
     }
+}
+
+/**
+ * Writes a blob at the given slash-separated path below a directory,
+ * creating intermediate subdirectories as needed.
+ */
+async function writeFileToDirectory(
+    root: FileSystemDirectoryHandle,
+    path: string,
+    blob: Blob
+): Promise<void> {
+    const segments = path.split("/").filter(segment => segment.length > 0);
+    const fileName = segments.pop()!;
+
+    let directory = root;
+    for (const segment of segments) {
+        directory = await directory.getDirectoryHandle(segment, {
+            create: true,
+        });
+    }
+
+    const handle = await directory.getFileHandle(fileName, { create: true });
+    const writable = await handle.createWritable();
+    await writable.write(blob);
+    await writable.close();
 }
 
 const downloadQueue: (() => void)[] = [];

--- a/frontend/src/types/dom/FileSystemAccess.d.ts
+++ b/frontend/src/types/dom/FileSystemAccess.d.ts
@@ -1,0 +1,9 @@
+/**
+ * File System Access API directory picker. Available in Chromium-based
+ * browsers only and not part of the TypeScript DOM lib.
+ */
+interface Window {
+    showDirectoryPicker?: (options?: {
+        mode?: "read" | "readwrite";
+    }) => Promise<FileSystemDirectoryHandle>;
+}

--- a/frontend/src/types/transfer/ShareSelection.ts
+++ b/frontend/src/types/transfer/ShareSelection.ts
@@ -1,0 +1,24 @@
+/**
+ * A set of items picked for sharing: loose files and whole folders.
+ * Produced by the file/folder inputs and by drag and drop.
+ */
+
+export interface FolderFile {
+    file: File;
+    /**
+     * Slash-separated path within the selection, including the folder name
+     * as first segment (same format as File.webkitRelativePath),
+     * e.g. "photos/2024/img.jpg".
+     */
+    relativePath: string;
+}
+
+export interface SharedFolder {
+    name: string;
+    files: FolderFile[];
+}
+
+export interface ShareSelection {
+    files: File[];
+    folders: SharedFolder[];
+}


### PR DESCRIPTION
Ordner können vollständig geteilt werden, per "Ordner hinzufügen" oder Drag and Drop. Jede Datei trägt ihren relativen Pfad und eine Ordner-ID in den Metadaten; beide Seiten zeigen den Ordner als einen aufklappbaren Eintrag mit Gesamtgröße und Fortschritt pro Datei. Unter Chromium wird der Ordner über showDirectoryPicker inklusive Unterordnerstruktur gespeichert; Firefox/Safari laden die Dateien wie bisher einzeln herunter. Kein ZIP, das Protokoll bleibt abwärtskompatibel.