### PR TITLE
Geräte umbenennen

### DIFF
--- a/backend/backend.tests/src/DeviceComponent/Dataacess/Impl/DeviceRepositoryTest.cs
+++ b/backend/backend.tests/src/DeviceComponent/Dataacess/Impl/DeviceRepositoryTest.cs
@@ -150,6 +150,41 @@ public class DeviceRepositoryTest
     }
 
     [Test]
+    public async Task RenameAsync_Updates_DisplayName()
+    {
+        var account = new Account("testuser", "testpassword");
+        var id = await _accountRepository.SaveAsync(account);
+        Assert.That(id, Is.EqualTo(1));
+        // add some device
+        const int accountId = 1;
+        Guid guid = Guid.NewGuid();
+        var device = new Device("testdevice", guid, accountId);
+        var uuid = await _deviceRepository.SaveDeviceAsync(device);
+        var result = await _deviceRepository.RenameDeviceAsync(accountId, uuid, "renamed device");
+        Assert.That(result, Is.EqualTo(1));
+        var deviceLoginDtos = await _deviceRepository.GetAllDisplayNamesForAccountAsync(accountId, Guid.Empty);
+        Assert.That(deviceLoginDtos, Has.Count.EqualTo(1));
+        Assert.That(deviceLoginDtos[0].DisplayName, Is.EqualTo("renamed device"));
+    }
+
+    [Test]
+    public async Task RenameAsync_RenamesNoDevice_IfDeviceUuid_OrAccountId_DoesntExist()
+    {
+        var account = new Account("testuser", "testpassword");
+        var id = await _accountRepository.SaveAsync(account);
+        Assert.That(id, Is.EqualTo(1));
+        // add some device
+        const int accountId = 1;
+        Guid guid = Guid.NewGuid();
+        var device = new Device("testdevice", guid, accountId);
+        var uuid = await _deviceRepository.SaveDeviceAsync(device);
+        var result = await _deviceRepository.RenameDeviceAsync(accountId, Guid.NewGuid(), "renamed device");
+        Assert.That(result, Is.EqualTo(0));
+        result = await _deviceRepository.RenameDeviceAsync(53, uuid, "renamed device");
+        Assert.That(result, Is.EqualTo(0));
+    }
+
+    [Test]
     public async Task DeleteAsync_DeletesNoDevice_IfDeviceUuid_OrAccountId_DoesntExist()
     {
         var account = new Account("testuser", "testpassword");

--- a/backend/backend.tests/src/DeviceComponent/Logic/Impl/DeviceHandlerTest.cs
+++ b/backend/backend.tests/src/DeviceComponent/Logic/Impl/DeviceHandlerTest.cs
@@ -237,4 +237,77 @@ public class DeviceHandlerTests
         var okResult = result as Ok<string>;
         Assert.That(okResult?.Value, Is.EqualTo("Device deleted successfully."));
     }
+
+    private static void SetRenameRequestBody(HttpContext context, Guid deviceUuid, string displayName)
+    {
+        var json = System.Text.Json.JsonSerializer.Serialize(new DeviceRenameDto
+        {
+            Uuid = deviceUuid,
+            DisplayName = displayName
+        });
+        var bytes = System.Text.Encoding.UTF8.GetBytes(json);
+        context.Request.Body = new MemoryStream(bytes);
+        context.Request.ContentType = "application/json";
+    }
+
+    [Test]
+    public async Task RenameDeviceAsync_WhenDeviceExists_RenamesDevice()
+    {
+        // Arrange
+        var deviceUuid = Guid.NewGuid();
+        var context = CreateValidContext("1", true, deviceUuid: deviceUuid, userAgent: "Windows Mozilla");
+        SetRenameRequestBody(context, deviceUuid, "  Mein Laptop  ");
+
+        _repoMock.Setup(r => r.GetDeviceByUuidAsync(deviceUuid))
+            .ReturnsAsync(new Device("TestDevice", deviceUuid, 1));
+        _repoMock.Setup(r => r.RenameDeviceAsync(1, deviceUuid, "Mein Laptop"))
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _deviceHandler.RenameDeviceAsync(context);
+
+        // Assert
+        Assert.That(result, Is.TypeOf<Ok<string>>());
+        var okResult = result as Ok<string>;
+        Assert.That(okResult?.Value, Is.EqualTo("Device renamed successfully."));
+        _repoMock.Verify(r => r.RenameDeviceAsync(1, deviceUuid, "Mein Laptop"), Times.Once);
+        _deviceServiceMock.Verify(
+            s => s.SendDeviceChangedMessage(1, "renamed", deviceUuid, "Mein Laptop", It.IsAny<string>()),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task RenameDeviceAsync_WhenDisplayNameInvalid_ReturnsBadRequest()
+    {
+        // Arrange
+        var deviceUuid = Guid.NewGuid();
+        var context = CreateValidContext("1", true, deviceUuid: deviceUuid, userAgent: "Windows Mozilla");
+        SetRenameRequestBody(context, deviceUuid, "  ");
+
+        // Act
+        var result = await _deviceHandler.RenameDeviceAsync(context);
+
+        // Assert
+        Assert.That(result, Is.TypeOf<BadRequest<string>>());
+        _repoMock.Verify(r => r.RenameDeviceAsync(It.IsAny<int>(), It.IsAny<Guid>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task RenameDeviceAsync_WhenDeviceBelongsToOtherAccount_ReturnsUnauthorized()
+    {
+        // Arrange
+        var deviceUuid = Guid.NewGuid();
+        var context = CreateValidContext("1", true, deviceUuid: deviceUuid, userAgent: "Windows Mozilla");
+        SetRenameRequestBody(context, deviceUuid, "Mein Laptop");
+
+        _repoMock.Setup(r => r.GetDeviceByUuidAsync(deviceUuid))
+            .ReturnsAsync(new Device("TestDevice", deviceUuid, 2));
+
+        // Act
+        var result = await _deviceHandler.RenameDeviceAsync(context);
+
+        // Assert
+        Assert.That(result, Is.TypeOf<UnauthorizedHttpResult>());
+        _repoMock.Verify(r => r.RenameDeviceAsync(It.IsAny<int>(), It.IsAny<Guid>(), It.IsAny<string>()), Times.Never);
+    }
 }

--- a/backend/backend/src/DeviceComponent/Common/DTOs/DeviceChangedMessage.cs
+++ b/backend/backend/src/DeviceComponent/Common/DTOs/DeviceChangedMessage.cs
@@ -11,7 +11,7 @@ public class DeviceChangedMessage : ITypedMessage
     public string InstanceTypeString => TypeString;
 
     [JsonPropertyName("action")]
-    public required string Action { get; set; } // "added" or "removed"
+    public required string Action { get; set; } // "added", "removed" or "renamed"
 
     [JsonPropertyName("deviceInfo")]
     public required DeviceInfo Device { get; set; }

--- a/backend/backend/src/DeviceComponent/Common/DTOs/DeviceRenameDTO.cs
+++ b/backend/backend/src/DeviceComponent/Common/DTOs/DeviceRenameDTO.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace backend.DeviceComponent.Common.DTOs;
+
+public class DeviceRenameDto
+{
+    [JsonPropertyName("uuid")]
+    public Guid Uuid { get; set; }
+
+    [JsonPropertyName("displayName")]
+    public string DisplayName { get; set; } = "";
+}

--- a/backend/backend/src/DeviceComponent/Common/Validators/DisplayNameValidator.cs
+++ b/backend/backend/src/DeviceComponent/Common/Validators/DisplayNameValidator.cs
@@ -4,12 +4,18 @@ namespace backend.DeviceComponent.Common.Validators;
 
 public class DisplayNameValidator
 {
+    public const int MaxDisplayNameLength = 64;
 
     public static void ValidateDisplayNameFormat(string displayName)
     {
         if (string.IsNullOrWhiteSpace(displayName) || displayName.Length < 3)
         {
             throw new InvalidDisplayNameException("Display Name must be at least 3 characters long.");
+        }
+
+        if (displayName.Length > MaxDisplayNameLength)
+        {
+            throw new InvalidDisplayNameException($"Display Name must be at most {MaxDisplayNameLength} characters long.");
         }
     }
 }

--- a/backend/backend/src/DeviceComponent/Dataaccess/Api/Repo/IDeviceRepository.cs
+++ b/backend/backend/src/DeviceComponent/Dataaccess/Api/Repo/IDeviceRepository.cs
@@ -8,5 +8,6 @@ public interface IDeviceRepository
     Task<Guid> SaveDeviceAsync(Device device);
     Task<List<DeviceLoginDto>> GetAllDisplayNamesForAccountAsync(int accountId, Guid uuid);
     Task<int> DeleteDeviceAsync(int accountId, Guid uuid);
+    Task<int> RenameDeviceAsync(int accountId, Guid uuid, string displayName);
     Task<Device?> GetDeviceByUuidAsync(Guid uuid);
 }

--- a/backend/backend/src/DeviceComponent/Dataaccess/Impl/DeviceRepository.cs
+++ b/backend/backend/src/DeviceComponent/Dataaccess/Impl/DeviceRepository.cs
@@ -64,6 +64,18 @@ public class DeviceRepository(NpgsqlDataSource _dataSource) : IDeviceRepository
         return await cmd.ExecuteNonQueryAsync(); // returns number of affected rows
     }
 
+    public async Task<int> RenameDeviceAsync(int accountId, Guid uuid, string displayName)
+    {
+        await using var cmd = _dataSource.CreateCommand(
+            "UPDATE devices SET display_name = @name WHERE uuid = @uuid AND account_id = @accountId"
+        );
+        cmd.Parameters.AddWithValue("@name", displayName);
+        cmd.Parameters.AddWithValue("@uuid", uuid);
+        cmd.Parameters.AddWithValue("@accountId", accountId);
+
+        return await cmd.ExecuteNonQueryAsync(); // returns number of affected rows
+    }
+
     public Task<Device?> GetDeviceByUuidAsync(Guid uuid)
     {
         return Task.Run(async () =>

--- a/backend/backend/src/DeviceComponent/Facade/Impl/DeviceRoutes.cs
+++ b/backend/backend/src/DeviceComponent/Facade/Impl/DeviceRoutes.cs
@@ -16,6 +16,9 @@ public class DeviceRoutes : IDeviceRoutes
         app.MapDelete("/device", (IDeviceHandler handler, HttpContext context) =>
             handler.DeleteDeviceAsync(context));
 
+        app.MapPatch("/device", (IDeviceHandler handler, HttpContext context) =>
+            handler.RenameDeviceAsync(context));
+
         return Task.CompletedTask;
     }
 }

--- a/backend/backend/src/DeviceComponent/Logic/Api/IDeviceHandler.cs
+++ b/backend/backend/src/DeviceComponent/Logic/Api/IDeviceHandler.cs
@@ -5,4 +5,5 @@ public interface IDeviceHandler
     Task<IResult> RegisterDeviceAsync(HttpContext context);
     Task<IResult> GetDevicesByUserAsync(HttpContext context);
     Task<IResult> DeleteDeviceAsync(HttpContext context);
+    Task<IResult> RenameDeviceAsync(HttpContext context);
 }

--- a/backend/backend/src/DeviceComponent/Logic/Api/IDeviceService.cs
+++ b/backend/backend/src/DeviceComponent/Logic/Api/IDeviceService.cs
@@ -28,7 +28,7 @@ public interface IDeviceService
 
     /// <summary>
     /// Sends a device-changed message to all active client tokens of the user.
-    /// This notifies all connected clients that a device was added or removed.
+    /// This notifies all connected clients that a device was added, removed or renamed.
     /// </summary>
     void SendDeviceChangedMessage(int userId, string action, Guid deviceUuid, string displayName, string status);
 }

--- a/backend/backend/src/DeviceComponent/Logic/Impl/DeviceHandler.cs
+++ b/backend/backend/src/DeviceComponent/Logic/Impl/DeviceHandler.cs
@@ -2,6 +2,8 @@ using System.Text.RegularExpressions;
 using backend.AccountComponent.Common.Api.DTOs;
 using backend.AccountComponent.Logic.Api;
 using backend.DeviceComponent.Common.DTOs;
+using backend.DeviceComponent.Common.Exception;
+using backend.DeviceComponent.Common.Validators;
 using backend.DeviceComponent.Dataaccess.Api.Entity;
 using backend.DeviceComponent.Dataaccess.Api.Repo;
 using backend.DeviceComponent.Logic.Api;
@@ -273,5 +275,70 @@ public class DeviceHandler(
         );
 
         return Results.Ok("Device deleted successfully.");
+    }
+
+    public async Task<IResult> RenameDeviceAsync(HttpContext context)
+    {
+        // Check for session cookie
+        if (!context.Request.Cookies.TryGetValue(".AspNetCore.Session", out var sessionToken))
+        {
+            return Results.Unauthorized();
+        }
+
+        var result = await login.HandleGetCurrentUser(context);
+        if (result is not Ok<LoginResponse>)
+        {
+            return Results.Unauthorized();
+        }
+
+        // Access the session using the sessionToken or from the session store
+        var accountId = context.Session.GetString("UserId");
+
+        if (string.IsNullOrEmpty(accountId))
+        {
+            return Results.Unauthorized();
+        }
+
+        if (!int.TryParse(accountId, out var parsedAccountId))
+        {
+            return Results.BadRequest("Invalid account ID in session.");
+        }
+
+        // Read device UUID and new display name from request body
+        var renameDto = await context.Request.ReadFromJsonAsync<DeviceRenameDto>();
+        if (renameDto == null || renameDto.Uuid == Guid.Empty)
+        {
+            return Results.BadRequest("Device UUID is required.");
+        }
+
+        var displayName = renameDto.DisplayName.Trim();
+        try
+        {
+            DisplayNameValidator.ValidateDisplayNameFormat(displayName);
+        }
+        catch (InvalidDisplayNameException e)
+        {
+            return Results.BadRequest(e.Message);
+        }
+
+        // Prüfen, ob das Device existiert und zu diesem Account gehört
+        var device = await repo.GetDeviceByUuidAsync(renameDto.Uuid);
+        if (device == null || device.GetAccountId() != parsedAccountId)
+        {
+            return Results.Unauthorized();
+        }
+
+        // Proceed with renaming the device
+        await repo.RenameDeviceAsync(parsedAccountId, renameDto.Uuid, displayName);
+
+        _deviceService.SendDeviceChangedMessage(
+            parsedAccountId,
+            "renamed",
+            renameDto.Uuid,
+            displayName,
+            _deviceService.GetDeviceStatus(renameDto.Uuid)
+        );
+
+        return Results.Ok("Device renamed successfully.");
     }
 }

--- a/backend/backend/src/Program.cs
+++ b/backend/backend/src/Program.cs
@@ -53,7 +53,7 @@ builder.Services.AddCors(options =>
                 .WithHeaders("Content-Type", "User-Agent", "Authorization")
                 .WithExposedHeaders("Location")
                 .AllowCredentials() // Required to allow session cookies
-                .WithMethods("GET", "POST", "DELETE")
+                .WithMethods("GET", "POST", "DELETE", "PATCH")
     )
 );
 

--- a/frontend/src/components/Connection/Devices/DeviceDisplay/DeviceDisplay.module.scss
+++ b/frontend/src/components/Connection/Devices/DeviceDisplay/DeviceDisplay.module.scss
@@ -38,3 +38,21 @@
     padding: var(--space-4);
     border-radius: var(--space-8);
 }
+
+.renameButton {
+    padding: var(--space-4);
+    border-radius: var(--space-8);
+}
+
+.nameInput {
+    width: 12ch;
+    padding: 0 var(--space-4);
+    background-color: var(--text-muted-5);
+    color: var(--text);
+    border: none;
+    border-bottom: 1px solid var(--text-muted);
+    border-radius: var(--space-4);
+
+    font-size: inherit;
+    font-family: inherit;
+}

--- a/frontend/src/components/Connection/Devices/DeviceDisplay/DeviceDisplay.tsx
+++ b/frontend/src/components/Connection/Devices/DeviceDisplay/DeviceDisplay.tsx
@@ -1,24 +1,33 @@
+import { useState } from "react";
 import { Device } from "../../../../types/device/Device";
 import { DeviceStatus } from "../../../../types/device/DeviceStatus";
 import css from "./DeviceDisplay.module.scss";
 import TrashIcon from "../../../../assets/actions/icons8-trash.svg?react";
+import EditIcon from "../../../../assets/actions/icons8-edit.svg?react";
 import Badge from "../../../Badge/Badge";
 import Button from "../../../Button/Button";
 import Tooltip from "../../../Tooltip/Tooltip";
 import Anchor from "../../../Anchor/Anchor";
 import FakeButton from "../../../FakeButton/FakeButton";
 
+const MAX_DEVICE_NAME_LENGTH = 64; // Linked to the backend DisplayNameValidator
+
 interface DeviceDisplayProps {
     device: Device;
     onConnect: (device: Device) => void;
     onDelete: (device: Device) => void;
+    onRename: (device: Device, newName: string) => void;
 }
 
 export default function DeviceDisplay({
     device,
     onConnect,
     onDelete,
+    onRename,
 }: DeviceDisplayProps) {
+    const [editing, setEditing] = useState(false);
+    const [editedName, setEditedName] = useState("");
+
     const getDeviceStatusClass = () => {
         switch (device.status) {
             case DeviceStatus.ONLINE:
@@ -41,6 +50,20 @@ export default function DeviceDisplay({
         }
     };
 
+    const startEditing = () => {
+        setEditedName(device.name);
+        setEditing(true);
+    };
+
+    const commitRename = () => {
+        setEditing(false);
+        const newName = editedName.trim();
+        if (newName.length === 0 || newName === device.name) {
+            return;
+        }
+        onRename(device, newName);
+    };
+
     return (
         <FakeButton
             className={css.deviceDisplay}
@@ -60,8 +83,41 @@ export default function DeviceDisplay({
                     className={`${css.statusIndicator} ${getDeviceStatusClass()}`}
                 />
             </Tooltip>
-            <span className={css.deviceName}>{device.name}</span>
+            {editing ? (
+                <input
+                    className={css.nameInput}
+                    value={editedName}
+                    maxLength={MAX_DEVICE_NAME_LENGTH}
+                    autoFocus
+                    onChange={e => setEditedName(e.target.value)}
+                    onClick={e => e.stopPropagation()}
+                    onKeyDown={e => {
+                        // Prevents FakeButton from treating Enter/Space as a connect click
+                        e.stopPropagation();
+                        if (e.key === "Enter") {
+                            commitRename();
+                        } else if (e.key === "Escape") {
+                            setEditing(false);
+                        }
+                    }}
+                    onBlur={commitRename}
+                />
+            ) : (
+                <span className={css.deviceName}>{device.name}</span>
+            )}
             {device.current && <Badge>DIESES GERÄT</Badge>}
+            <Tooltip content={"Gerät umbenennen"}>
+                <Button
+                    color_scheme={"neutral"}
+                    className={css.renameButton}
+                    onClick={e => {
+                        e.stopPropagation();
+                        startEditing();
+                    }}
+                >
+                    <EditIcon />
+                </Button>
+            </Tooltip>
             <Tooltip content={"Gerät aus registrierten Geräten entfernen"}>
                 <Button
                     color_scheme={"error"}

--- a/frontend/src/components/Connection/Devices/DeviceList/DeviceList.tsx
+++ b/frontend/src/components/Connection/Devices/DeviceList/DeviceList.tsx
@@ -11,6 +11,7 @@ export default function DeviceList() {
         registerCurrentDevice,
         connectToDevice,
         deleteDevice,
+        renameDevice,
     } = useDevices();
 
     return (
@@ -32,6 +33,9 @@ export default function DeviceList() {
                     device={device}
                     onConnect={connectToDevice}
                     onDelete={() => void deleteDevice(device)}
+                    onRename={(device, newName) =>
+                        void renameDevice(device, newName)
+                    }
                 />
             ))}
         </div>

--- a/frontend/src/hooks/useDevices.tsx
+++ b/frontend/src/hooks/useDevices.tsx
@@ -180,6 +180,48 @@ export const useDevices = () => {
     }, []);
 
     /**
+     * Renames a device by sending its UUID and the new name to the server.
+     */
+    const renameDevice = useCallback(
+        async (device: Device, newName: string) => {
+            const [response, err] = await errorAsValue(
+                fetch(`${getRuntimeEnvVars().backendUrl}/device`, {
+                    method: "PATCH",
+                    credentials: "include",
+                    body: JSON.stringify({
+                        uuid: device.uuid,
+                        displayName: newName,
+                    }),
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
+                })
+            );
+
+            if (err) {
+                toast.error(
+                    "Fehler beim Umbenennen des Geräts. Bitte versuche es später erneut."
+                );
+                console.error("Error renaming device:", err);
+                return;
+            } else if (!response.ok) {
+                toast.error(
+                    "Fehler beim Umbenennen des Geräts. Bitte versuche es später erneut."
+                );
+                console.error("Error renaming device:", response.statusText);
+                return;
+            }
+
+            setDevices(prevDevices =>
+                prevDevices.map(d =>
+                    d.uuid === device.uuid ? { ...d, name: newName } : d
+                )
+            );
+        },
+        []
+    );
+
+    /**
      * Initiates a quick connect to another device.
      */
     const connectToDevice = useCallback(
@@ -269,6 +311,14 @@ export const useDevices = () => {
                 setDevices(prevDevices =>
                     prevDevices.filter(d => d.uuid !== deviceInfo.uuid)
                 );
+            } else if (action === "renamed") {
+                setDevices(prevDevices =>
+                    prevDevices.map(device =>
+                        device.uuid === deviceInfo.uuid
+                            ? { ...device, name: deviceInfo.displayName }
+                            : device
+                    )
+                );
             }
         };
 
@@ -301,6 +351,7 @@ export const useDevices = () => {
         currentDeviceRegistered,
         registerCurrentDevice,
         deleteDevice,
+        renameDevice,
         connectToDevice,
     };
 };

--- a/frontend/src/types/device/DeviceChangedMessage.ts
+++ b/frontend/src/types/device/DeviceChangedMessage.ts
@@ -11,12 +11,12 @@ export interface DeviceInfo {
 export class DeviceChangedMessage implements ITypedMessage {
     public readonly type = MessageType.DEVICE_CHANGED;
     public msg: {
-        action: "added" | "removed";
+        action: "added" | "removed" | "renamed";
         deviceInfo: DeviceInfo;
     };
 
     public constructor(msg: {
-        action: "added" | "removed";
+        action: "added" | "removed" | "renamed";
         deviceInfo: DeviceInfo;
     }) {
         this.msg = msg;


### PR DESCRIPTION
Neben dem Löschen-Button gibt es einen Stift-Button, der den Gerätenamen in ein Eingabefeld verwandelt; Enter speichert, Escape bricht ab. Das Backend stellt PATCH /device bereit (gleiche Authentifizierung wie Löschen, Name getrimmt, 3 bis 64 Zeichen) und informiert alle verbundenen Clients per WebSocket.
