### PR TITLE
Gleiches Gerät kann mit mehreren Accounts verknüpft werden

### DIFF
--- a/backend/backend.tests/src/DeviceComponent/Dataacess/Impl/DeviceRepositoryTest.cs
+++ b/backend/backend.tests/src/DeviceComponent/Dataacess/Impl/DeviceRepositoryTest.cs
@@ -7,7 +7,6 @@ using backend.DeviceComponent.Dataaccess.Api.Repo;
 using backend.DeviceComponent.Dataaccess.Impl;
 using backend.tests.TestUtils;
 using Microsoft.Extensions.DependencyInjection;
-using Npgsql;
 
 namespace backend.tests.DeviceComponent.Dataacess.Impl;
 
@@ -69,7 +68,7 @@ public class DeviceRepositoryTest
     }
 
     [Test]
-    public async Task SaveAsync_With_Duplicate_Uuid_Throws_PostgresException()
+    public async Task SaveAsync_With_Duplicate_Uuid_And_Account_Is_Idempotent()
     {
         var account = new Account("testuser", "testpassword");
         var id = await _accountRepository.SaveAsync(account);
@@ -79,11 +78,33 @@ public class DeviceRepositoryTest
         var uuid = await _deviceRepository.SaveDeviceAsync(device);
         Assert.That(uuid, Is.EqualTo(guid));
         var device2 = new Device("testdevice", guid, 1);
-        var ex = Assert.ThrowsAsync<PostgresException>(async () =>
-        {
-            await _deviceRepository.SaveDeviceAsync(device2);
-        });
-        Assert.That(ex, Is.Not.Null);
+        var uuid2 = await _deviceRepository.SaveDeviceAsync(device2);
+        Assert.That(uuid2, Is.EqualTo(guid));
+        var devices = await _deviceRepository.GetAllDisplayNamesForAccountAsync(1);
+        Assert.That(devices, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public async Task SaveAsync_Allows_Same_Uuid_For_Multiple_Accounts()
+    {
+        var id = await _accountRepository.SaveAsync(new Account("testuser", "testpassword"));
+        Assert.That(id, Is.EqualTo(1));
+        var id2 = await _accountRepository.SaveAsync(new Account("testuser2", "testpassword"));
+        Assert.That(id2, Is.EqualTo(2));
+
+        Guid guid = Guid.NewGuid();
+        await _deviceRepository.SaveDeviceAsync(new Device("testdevice", guid, 1));
+        await _deviceRepository.SaveDeviceAsync(new Device("testdevice", guid, 2));
+
+        var accountIds = await _deviceRepository.GetAccountIdsByDeviceUuidAsync(guid);
+        Assert.That(accountIds, Is.EquivalentTo(new[] { 1, 2 }));
+    }
+
+    [Test]
+    public async Task GetAccountIdsByDeviceUuidAsync_Returns_EmptyList_For_Unknown_Uuid()
+    {
+        var accountIds = await _deviceRepository.GetAccountIdsByDeviceUuidAsync(Guid.NewGuid());
+        Assert.That(accountIds, Is.Empty);
     }
 
     [Test]
@@ -102,7 +123,7 @@ public class DeviceRepositoryTest
         var uuid2 = await _deviceRepository.SaveDeviceAsync(device2);
         Assert.That(uuid, Is.EqualTo(guid));
         Assert.That(uuid2, Is.EqualTo(guid2));
-        var deviceLoginDtos = await _deviceRepository.GetAllDisplayNamesForAccountAsync(accountId, Guid.Empty);
+        var deviceLoginDtos = await _deviceRepository.GetAllDisplayNamesForAccountAsync(accountId);
         Assert.That(deviceLoginDtos, Is.Not.Null);
         Assert.Multiple(() =>
         {
@@ -119,7 +140,7 @@ public class DeviceRepositoryTest
         var account = new Account("testuser", "testpassword");
         var id = await _accountRepository.SaveAsync(account);
         Assert.That(id, Is.EqualTo(1));
-        var nonExistentDevices = await _deviceRepository.GetAllDisplayNamesForAccountAsync(2, Guid.Empty);
+        var nonExistentDevices = await _deviceRepository.GetAllDisplayNamesForAccountAsync(2);
         Assert.That(nonExistentDevices, Is.Empty);
 
         // add some device
@@ -129,7 +150,7 @@ public class DeviceRepositoryTest
         await _deviceRepository.SaveDeviceAsync(device);
 
         // get nonexistent account again
-        var nonExistentDevices2 = await _deviceRepository.GetAllDisplayNamesForAccountAsync(2, Guid.Empty);
+        var nonExistentDevices2 = await _deviceRepository.GetAllDisplayNamesForAccountAsync(2);
         Assert.That(nonExistentDevices, Is.Empty);
     }
 
@@ -169,5 +190,26 @@ public class DeviceRepositoryTest
         Assert.That(result, Is.EqualTo(0));
         result = await _deviceRepository.DeleteDeviceAsync(accountId, guid);
         Assert.That(result, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task DeleteAsync_Removes_Only_Link_Of_Acting_Account()
+    {
+        var id = await _accountRepository.SaveAsync(new Account("testuser", "testpassword"));
+        Assert.That(id, Is.EqualTo(1));
+        var id2 = await _accountRepository.SaveAsync(new Account("testuser2", "testpassword"));
+        Assert.That(id2, Is.EqualTo(2));
+
+        Guid guid = Guid.NewGuid();
+        await _deviceRepository.SaveDeviceAsync(new Device("testdevice", guid, 1));
+        await _deviceRepository.SaveDeviceAsync(new Device("testdevice", guid, 2));
+
+        var result = await _deviceRepository.DeleteDeviceAsync(1, guid);
+        Assert.That(result, Is.EqualTo(1));
+
+        var deviceForAccount1 = await _deviceRepository.GetDeviceByUuidAsync(guid, 1);
+        Assert.That(deviceForAccount1, Is.Null);
+        var deviceForAccount2 = await _deviceRepository.GetDeviceByUuidAsync(guid, 2);
+        Assert.That(deviceForAccount2, Is.Not.Null);
     }
 }

--- a/backend/backend.tests/src/DeviceComponent/Logic/Impl/DeviceHandlerTest.cs
+++ b/backend/backend.tests/src/DeviceComponent/Logic/Impl/DeviceHandlerTest.cs
@@ -70,11 +70,14 @@ public class DeviceHandlerTests
     }
 
     [Test]
-    public async Task RegisterDeviceAsync_WhenDeviceAlreadyRegistered_ReturnsOkWithOverrittenUuid()
+    public async Task RegisterDeviceAsync_WhenCookiePresent_ReusesUuidFromCookie()
     {
         Guid guid = Guid.NewGuid();
         // Arrange
         var context = CreateValidContext("6", true, deviceUuid: guid);
+
+        _repoMock.Setup(r => r.SaveDeviceAsync(It.IsAny<Device>()))
+                 .ReturnsAsync(guid);
 
         // Act
         var result = await _deviceHandler.RegisterDeviceAsync(context);
@@ -83,7 +86,27 @@ public class DeviceHandlerTests
         Assert.That(result, Is.TypeOf<Ok<DeviceRegisterDto>>());
         var okResult = result as Ok<DeviceRegisterDto>;
         Assert.That(okResult?.Value, Has.Property("uuid"));
-        Assert.That(okResult?.Value!.uuid, !Is.EqualTo(guid));
+        Assert.That(okResult?.Value!.uuid, Is.EqualTo(guid));
+    }
+
+    [Test]
+    public async Task RegisterDeviceAsync_WhenDeviceAlreadyRegisteredForAccount_IsIdempotent()
+    {
+        Guid guid = Guid.NewGuid();
+        // Arrange
+        var context = CreateValidContext("6", true, deviceUuid: guid);
+
+        _repoMock.Setup(r => r.GetDeviceByUuidAsync(guid, 6))
+                 .ReturnsAsync(new Device("TestDevice", guid, 6));
+
+        // Act
+        var result = await _deviceHandler.RegisterDeviceAsync(context);
+
+        // Assert
+        Assert.That(result, Is.TypeOf<Ok<DeviceRegisterDto>>());
+        var okResult = result as Ok<DeviceRegisterDto>;
+        Assert.That(okResult?.Value!.uuid, Is.EqualTo(guid));
+        _repoMock.Verify(r => r.SaveDeviceAsync(It.IsAny<Device>()), Times.Never);
     }
 
     [Test]
@@ -111,7 +134,7 @@ public class DeviceHandlerTests
         // Arrange
         var context = CreateValidContext("1", true, deviceUuid: guid, userAgent: "Windows Mozilla");
 
-        _repoMock.Setup(r => r.GetAllDisplayNamesForAccountAsync(1, guid))
+        _repoMock.Setup(r => r.GetAllDisplayNamesForAccountAsync(1))
                  .ReturnsAsync(new List<DeviceLoginDto>
                  {
                      new DeviceLoginDto { DisplayName = "Windows Mozilla",  Uuid = guid, Status = "online" },
@@ -135,7 +158,7 @@ public class DeviceHandlerTests
         // Arrange
         var context = CreateValidContext("1", true, userAgent: "Windows Mozilla");
 
-        _repoMock.Setup(r => r.GetAllDisplayNamesForAccountAsync(1, It.IsAny<Guid>()))
+        _repoMock.Setup(r => r.GetAllDisplayNamesForAccountAsync(1))
             .ReturnsAsync(new List<DeviceLoginDto>
             {
                 new() { DisplayName = "Windows Mozilla",  Uuid = Guid.Empty, Status = "online" },
@@ -184,7 +207,7 @@ public class DeviceHandlerTests
         var userIdString = context.Session.GetString("UserId") ?? "1";
         _repoMock.Setup(r => r.SaveDeviceAsync(It.IsAny<Device>()))
             .ReturnsAsync(deviceUuid);
-        _repoMock.Setup(r => r.GetDeviceByUuidAsync(deviceUuid))
+        _repoMock.Setup(r => r.GetDeviceByUuidAsync(deviceUuid, int.Parse(userIdString)))
             .ReturnsAsync(new Device("TestDevice", deviceUuid, int.Parse(userIdString)));
         _repoMock.Setup(r => r.DeleteDeviceAsync(int.Parse(userIdString), deviceUuid))
             .ReturnsAsync(1);
@@ -224,7 +247,7 @@ public class DeviceHandlerTests
             .ReturnsAsync(Results.Ok(new LoginResponse("Logged in successfully")));
 
         var userIdString = context.Session.GetString("UserId") ?? "1";
-        _repoMock.Setup(r => r.GetDeviceByUuidAsync(deviceUuid))
+        _repoMock.Setup(r => r.GetDeviceByUuidAsync(deviceUuid, int.Parse(userIdString)))
             .ReturnsAsync(new Device("TestDevice", deviceUuid, int.Parse(userIdString)));
         _repoMock.Setup(r => r.DeleteDeviceAsync(int.Parse(userIdString), deviceUuid))
             .ReturnsAsync(1);
@@ -236,5 +259,29 @@ public class DeviceHandlerTests
         Assert.That(result, Is.TypeOf<Ok<string>>());
         var okResult = result as Ok<string>;
         Assert.That(okResult?.Value, Is.EqualTo("Device deleted successfully."));
+    }
+
+    [Test]
+    public async Task DeleteDevice_WhenNotRegisteredForAccount_ReturnsUnauthorized()
+    {
+        // Arrange
+        var deviceUuid = Guid.NewGuid();
+        var context = CreateValidContext("1", true, deviceUuid: deviceUuid, userAgent: "Windows Mozilla");
+
+        var json = System.Text.Json.JsonSerializer.Serialize(deviceUuid);
+        var bytes = System.Text.Encoding.UTF8.GetBytes(json);
+        context.Request.Body = new MemoryStream(bytes);
+        context.Request.ContentType = "application/json";
+
+        // The device is not registered for account 1
+        _repoMock.Setup(r => r.GetDeviceByUuidAsync(deviceUuid, 1))
+            .ReturnsAsync((Device?)null);
+
+        // Act
+        var result = await _deviceHandler.DeleteDeviceAsync(context);
+
+        // Assert
+        Assert.That(result, Is.TypeOf<UnauthorizedHttpResult>());
+        _repoMock.Verify(r => r.DeleteDeviceAsync(It.IsAny<int>(), It.IsAny<Guid>()), Times.Never);
     }
 }

--- a/backend/backend/src/ConnectionComponent/Logic/Impl/QuickConnectService.cs
+++ b/backend/backend/src/ConnectionComponent/Logic/Impl/QuickConnectService.cs
@@ -26,16 +26,13 @@ public class QuickConnectService(
 
         using var scope = _scopeFactory.CreateScope();
         var deviceRepository = scope.ServiceProvider.GetRequiredService<IDeviceRepository>();
-        var device = await deviceRepository.GetDeviceByUuidAsync(deviceUuid);
+        var device = await deviceRepository.GetDeviceByUuidAsync(
+            deviceUuid,
+            requestingClientId.Value
+        );
         if (device == null)
         {
-            // Device with the given UUID does not exist.
-            return;
-        }
-
-        if (device.GetAccountId() != requestingClientId)
-        {
-            // Device does not belong to the requesting client.
+            // Device is not registered for the requesting client.
             return;
         }
 

--- a/backend/backend/src/DeviceComponent/Dataaccess/Api/Repo/IDeviceRepository.cs
+++ b/backend/backend/src/DeviceComponent/Dataaccess/Api/Repo/IDeviceRepository.cs
@@ -6,7 +6,8 @@ namespace backend.DeviceComponent.Dataaccess.Api.Repo;
 public interface IDeviceRepository
 {
     Task<Guid> SaveDeviceAsync(Device device);
-    Task<List<DeviceLoginDto>> GetAllDisplayNamesForAccountAsync(int accountId, Guid uuid);
+    Task<List<DeviceLoginDto>> GetAllDisplayNamesForAccountAsync(int accountId);
     Task<int> DeleteDeviceAsync(int accountId, Guid uuid);
-    Task<Device?> GetDeviceByUuidAsync(Guid uuid);
+    Task<Device?> GetDeviceByUuidAsync(Guid uuid, int accountId);
+    Task<List<int>> GetAccountIdsByDeviceUuidAsync(Guid uuid);
 }

--- a/backend/backend/src/DeviceComponent/Dataaccess/Impl/DeviceRepository.cs
+++ b/backend/backend/src/DeviceComponent/Dataaccess/Impl/DeviceRepository.cs
@@ -7,25 +7,28 @@ namespace backend.DeviceComponent.Dataaccess.Impl;
 
 public class DeviceRepository(NpgsqlDataSource _dataSource) : IDeviceRepository
 {
+    /// <summary>
+    /// Saves the device registration for the account.
+    /// Registering the same device twice for the same account is idempotent.
+    /// </summary>
     public async Task<Guid> SaveDeviceAsync(Device device)
     {
         await using var cmd = _dataSource.CreateCommand(
-            "INSERT INTO devices (uuid, display_name, account_id) VALUES (@uuid, @name, @accountId)"
+            "INSERT INTO devices (uuid, display_name, account_id) VALUES (@uuid, @name, @accountId) "
+                + "ON CONFLICT (uuid, account_id) DO NOTHING"
         );
         cmd.Parameters.AddWithValue("uuid", device.GetUuid());
         cmd.Parameters.AddWithValue("name", device.GetDisplayName());
         cmd.Parameters.AddWithValue("accountId", device.GetAccountId());
 
-        var rows = await cmd.ExecuteNonQueryAsync();
-        if (rows == 1) return device.GetUuid();
-
-        throw new InvalidOperationException("Insert failed.");
+        await cmd.ExecuteNonQueryAsync();
+        return device.GetUuid();
     }
 
     /// <summary>
     /// The returned DeviceLoginDtos don't have a status set.
     /// </summary>
-    public async Task<List<DeviceLoginDto>> GetAllDisplayNamesForAccountAsync(int accountId, Guid uuid)
+    public async Task<List<DeviceLoginDto>> GetAllDisplayNamesForAccountAsync(int accountId)
     {
         await using var cmd = _dataSource.CreateCommand(
             "SELECT uuid, display_name FROM devices WHERE account_id = @accountId"
@@ -34,10 +37,6 @@ public class DeviceRepository(NpgsqlDataSource _dataSource) : IDeviceRepository
 
         await using var reader = await cmd.ExecuteReaderAsync();
         var devices = new List<DeviceLoginDto>();
-        if (uuid == Guid.Empty)
-        {
-            uuid = Guid.Parse("00000000-0000-0000-0001-294128421414"); // Never fails
-        }
 
         while (await reader.ReadAsync())
         {
@@ -64,25 +63,43 @@ public class DeviceRepository(NpgsqlDataSource _dataSource) : IDeviceRepository
         return await cmd.ExecuteNonQueryAsync(); // returns number of affected rows
     }
 
-    public Task<Device?> GetDeviceByUuidAsync(Guid uuid)
+    public async Task<Device?> GetDeviceByUuidAsync(Guid uuid, int accountId)
     {
-        return Task.Run(async () =>
-        {
-            await using var cmd = _dataSource.CreateCommand(
-                "SELECT uuid, display_name, account_id FROM devices WHERE uuid = @uuid"
-            );
-            cmd.Parameters.AddWithValue("uuid", uuid);
+        await using var cmd = _dataSource.CreateCommand(
+            "SELECT uuid, display_name, account_id FROM devices WHERE uuid = @uuid AND account_id = @accountId"
+        );
+        cmd.Parameters.AddWithValue("uuid", uuid);
+        cmd.Parameters.AddWithValue("accountId", accountId);
 
-            await using var reader = await cmd.ExecuteReaderAsync();
-            if (await reader.ReadAsync())
-            {
-                return new Device(
-                    reader.GetString(1), // display_name
-                    reader.GetGuid(0), // uuid
-                    reader.GetInt32(2) // account_id
-                );
-            }
-            return null; // No device found with the given UUID
-        });
+        await using var reader = await cmd.ExecuteReaderAsync();
+        if (await reader.ReadAsync())
+        {
+            return new Device(
+                reader.GetString(1), // display_name
+                reader.GetGuid(0), // uuid
+                reader.GetInt32(2) // account_id
+            );
+        }
+        return null; // The device is not registered for the given account
+    }
+
+    /// <summary>
+    /// Returns the ids of all accounts that registered the device.
+    /// The list is empty if no account registered the device.
+    /// </summary>
+    public async Task<List<int>> GetAccountIdsByDeviceUuidAsync(Guid uuid)
+    {
+        await using var cmd = _dataSource.CreateCommand(
+            "SELECT account_id FROM devices WHERE uuid = @uuid"
+        );
+        cmd.Parameters.AddWithValue("uuid", uuid);
+
+        await using var reader = await cmd.ExecuteReaderAsync();
+        var accountIds = new List<int>();
+        while (await reader.ReadAsync())
+        {
+            accountIds.Add(reader.GetInt32(0));
+        }
+        return accountIds;
     }
 }

--- a/backend/backend/src/DeviceComponent/Logic/Impl/DeviceHandler.cs
+++ b/backend/backend/src/DeviceComponent/Logic/Impl/DeviceHandler.cs
@@ -42,26 +42,41 @@ public class DeviceHandler(
         string displayNameRaw = context.Request.Headers["User-Agent"].ToString();
         string displayName = GetBrowserAndOs(displayNameRaw);
 
-        // Generate a new UUID for the device
-        var deviceUuid = Guid.NewGuid();
+        // Reuse the UUID from an existing cookie so the device keeps its identity across accounts.
+        // The cookie is only set once and never overwritten.
+        var hasValidCookie = Guid.TryParse(context.Request.Cookies["deviceUuid"], out var deviceUuid);
+        if (!hasValidCookie)
+        {
+            deviceUuid = Guid.NewGuid();
+        }
+
+        var existingDevice = await repo.GetDeviceByUuidAsync(deviceUuid, accountId);
+        if (existingDevice != null)
+        {
+            // The account already registered this device
+            return Results.Ok(new DeviceRegisterDto { uuid = deviceUuid });
+        }
 
         // Create a new device object to save in the repository
         var device = Device.Of(displayName, deviceUuid, accountId);
         // Save the device to the repository (database)
         await repo.SaveDeviceAsync(device);
 
-        context.Response.Cookies.Append(
-            "deviceUuid",
-            deviceUuid.ToString(),
-            new CookieOptions
-            {
-                HttpOnly = false, // Client needs to access this cookie via JavaScript to send heartbeats and check if the local device is registered; THIS ALSO MEANS THAT THE COOKIE IS NOT SECURE (you may validate the cookie on the server side by using the auth session token)
-                IsEssential = true,
-                SameSite = SameSiteMode.Lax,
-                Expires = DateTimeOffset.UtcNow.AddYears(5),
-                Domain = cookieDomain,
-            }
-        );
+        if (!hasValidCookie)
+        {
+            context.Response.Cookies.Append(
+                "deviceUuid",
+                deviceUuid.ToString(),
+                new CookieOptions
+                {
+                    HttpOnly = false, // Client needs to access this cookie via JavaScript to send heartbeats and check if the local device is registered; THIS ALSO MEANS THAT THE COOKIE IS NOT SECURE (you may validate the cookie on the server side by using the auth session token)
+                    IsEssential = true,
+                    SameSite = SameSiteMode.Lax,
+                    Expires = DateTimeOffset.UtcNow.AddYears(5),
+                    Domain = cookieDomain,
+                }
+            );
+        }
 
         _deviceService.SendDeviceChangedMessage(
             accountId,
@@ -162,44 +177,34 @@ public class DeviceHandler(
             return Results.BadRequest("Invalid account ID in session.");
         }
 
-        var deviceUuid = context.Request.Cookies["deviceUuid"];
-        List<DeviceLoginDto>? devices;
-        if (!string.IsNullOrEmpty(deviceUuid))
-        {
-            Guid deviceGuid;
-            try
-            {
-                deviceGuid = Guid.Parse(deviceUuid);
-            }
-            catch (FormatException)
-            {
-                deviceGuid = Guid.Empty;
-            }
+        var devices = await repo.GetAllDisplayNamesForAccountAsync(parsedAccountId);
 
-            devices = await repo.GetAllDisplayNamesForAccountAsync(parsedAccountId, deviceGuid);
-            var exists = devices.Any(d => d.Uuid == deviceGuid);
-            if (!exists)
-            {
-                // Cookie löschen, weil das Gerät nicht mehr existiert
-                context.Response.Cookies.Append(
-                    "deviceUuid",
-                    "",
-                    new CookieOptions
-                    {
-                        Expires = DateTimeOffset.UtcNow.AddDays(-1),
-                        HttpOnly = false,
-                        IsEssential = true,
-                        SameSite = SameSiteMode.Lax,
-                        Path = "/",
-                        Domain = cookieDomain,
-                    }
-                );
-            }
-        }
-        // Proceed with fetching the devices for the user
-        else
+        var deviceUuid = context.Request.Cookies["deviceUuid"];
+        if (Guid.TryParse(deviceUuid, out var deviceGuid))
         {
-            devices = await repo.GetAllDisplayNamesForAccountAsync(parsedAccountId, Guid.Empty);
+            var registeredForAccount = devices.Any(d => d.Uuid == deviceGuid);
+            if (!registeredForAccount)
+            {
+                // Another account may still have the device registered, in that case the cookie must stay.
+                var accountIds = await repo.GetAccountIdsByDeviceUuidAsync(deviceGuid);
+                if (accountIds.Count == 0)
+                {
+                    // Cookie löschen, weil das Gerät nicht mehr existiert
+                    context.Response.Cookies.Append(
+                        "deviceUuid",
+                        "",
+                        new CookieOptions
+                        {
+                            Expires = DateTimeOffset.UtcNow.AddDays(-1),
+                            HttpOnly = false,
+                            IsEssential = true,
+                            SameSite = SameSiteMode.Lax,
+                            Path = "/",
+                            Domain = cookieDomain,
+                        }
+                    );
+                }
+            }
         }
 
         var deviceResponse = new DeviceResponseDTO
@@ -251,16 +256,16 @@ public class DeviceHandler(
             return Results.BadRequest("Device UUID is required.");
         }
 
-        // Prüfen, ob das Device existiert und zu diesem Account gehört
-        var device = await repo.GetDeviceByUuidAsync(deviceGuid);
-        if (device == null || device.GetAccountId() != parsedAccountId)
+        // Prüfen, ob das Device für diesen Account registriert ist
+        var device = await repo.GetDeviceByUuidAsync(deviceGuid, parsedAccountId);
+        if (device == null)
         {
             return Results.Unauthorized();
         }
 
         var deviceDisplayName = device.GetDisplayName(); // TODO
 
-        // Proceed with deleting the device
+        // Only the link of the acting account is removed, other accounts keep the device
         await repo.DeleteDeviceAsync(parsedAccountId, deviceGuid);
         _deviceService.HandleDeviceDelete(deviceGuid, parsedAccountId, "offline");
 

--- a/backend/backend/src/DeviceComponent/Logic/Impl/DeviceService.cs
+++ b/backend/backend/src/DeviceComponent/Logic/Impl/DeviceService.cs
@@ -75,19 +75,17 @@ public class DeviceService(ILogger<DeviceService> logger) : IDeviceService
 
                 using var scope = _scopeFactory.CreateScope();
                 var repo = scope.ServiceProvider.GetRequiredService<IDeviceRepository>();
-                var device = await repo.GetDeviceByUuidAsync(kvp.Value.DeviceGuid);
+                var accountIds = await repo.GetAccountIdsByDeviceUuidAsync(kvp.Value.DeviceGuid);
 
-                if (device == null)
+                // The list is empty if the device was deleted by all accounts in the meantime
+                foreach (var accountId in accountIds)
                 {
-                    // Something went wrong, the device should be in the database if it is in the _activeDevices list
-                    return;
+                    SendHeartbeatToAllActiveClientTokens(
+                        accountId,
+                        kvp.Value.DeviceGuid,
+                        "offline"
+                    );
                 }
-
-                SendHeartbeatToAllActiveClientTokens(
-                    device.GetAccountId(),
-                    kvp.Value.DeviceGuid,
-                    "offline"
-                );
             }
         }
     }
@@ -131,9 +129,9 @@ public class DeviceService(ILogger<DeviceService> logger) : IDeviceService
 
         using var scope = _scopeFactory.CreateScope();
         var repo = scope.ServiceProvider.GetRequiredService<IDeviceRepository>();
-        var device = await repo.GetDeviceByUuidAsync(message.Uuid);
+        var accountIds = await repo.GetAccountIdsByDeviceUuidAsync(message.Uuid);
 
-        if (device == null)
+        if (accountIds.Count == 0)
         {
             // Device not found in the database
             logger.LogDebug(
@@ -142,11 +140,11 @@ public class DeviceService(ILogger<DeviceService> logger) : IDeviceService
             return;
         }
 
-        if (device.GetAccountId() != realUserId)
+        if (!accountIds.Contains(realUserId.Value))
         {
-            // Device does not belong to the sending user
+            // Device is not registered for the sending user
             logger.LogDebug(
-                $"Device with UUID {message.Uuid} does not belong to user {realUserId}. Heartbeat is not valid."
+                $"Device with UUID {message.Uuid} is not registered for user {realUserId}. Heartbeat is not valid."
             );
             return;
         }
@@ -185,7 +183,11 @@ public class DeviceService(ILogger<DeviceService> logger) : IDeviceService
         }
 
         // TODO maybe exlude sender token from the forwarded list
-        SendHeartbeatToAllActiveClientTokens(realUserId.Value, message.Uuid, message.DeviceStatus);
+        // Forward the heartbeat to all accounts that registered the device
+        foreach (var accountId in accountIds)
+        {
+            SendHeartbeatToAllActiveClientTokens(accountId, message.Uuid, message.DeviceStatus);
+        }
     }
 
     public void HandleDeviceDelete(Guid uuid, int userId, string deviceStatus)
@@ -193,13 +195,21 @@ public class DeviceService(ILogger<DeviceService> logger) : IDeviceService
         // Delete from the _activeDevices list
         foreach (var kvp in _activeDevices.ToArray())
         {
-            if (kvp.Value.DeviceGuid == uuid)
+            if (kvp.Value.DeviceGuid != uuid)
             {
-                _activeDevices.TryRemove(kvp.Key, out _);
-                logger.LogDebug(
-                    $"Removed deleted device {kvp.Value.DeviceGuid} for client {kvp.Key}"
-                );
+                continue;
             }
+
+            if (_webSocketHandler.GetUserIdForClientToken(kvp.Key) != userId)
+            {
+                // The client is logged in with another account that may still have the device registered
+                continue;
+            }
+
+            _activeDevices.TryRemove(kvp.Key, out _);
+            logger.LogDebug(
+                $"Removed deleted device {kvp.Value.DeviceGuid} for client {kvp.Key}"
+            );
         }
     }
 

--- a/database/database_ddl/public/02_devices.sql
+++ b/database/database_ddl/public/02_devices.sql
@@ -1,8 +1,9 @@
 create table devices
 (
-    uuid UUID NOT NULL CONSTRAINT devices_pk PRIMARY KEY,
+    uuid UUID NOT NULL,
     display_name TEXT NOT NULL,
     account_id INTEGER NOT NULL,
+    CONSTRAINT devices_pk PRIMARY KEY (uuid, account_id),
     CONSTRAINT users_fk FOREIGN KEY (account_id) REFERENCES users(id) ON DELETE CASCADE
 );
 


### PR DESCRIPTION
Die Tabelle devices nutzt jetzt den zusammengesetzten Primärschlüssel (uuid, account_id), ein Gerät kann von beliebig vielen Accounts registriert werden. Der deviceUuid-Cookie wird nur einmalig gesetzt und nie überschrieben. Heartbeats gehen an alle Accounts, die das Gerät registriert haben; Löschen entfernt nur die Verknüpfung des handelnden Accounts. Bestehende Datenbanken benötigen einmalig die ALTER-Statements für den neuen Primärschlüssel.
