### PR TITLE
Tooltip: hoverable-Prop für anklickbaren Tooltip-Inhalt

### DIFF
--- a/frontend/src/components/Connection/Devices/DeviceDisplay/DeviceDisplay.tsx
+++ b/frontend/src/components/Connection/Devices/DeviceDisplay/DeviceDisplay.tsx
@@ -55,6 +55,7 @@ export default function DeviceDisplay({
                     </>
                 }
                 showArrow={true}
+                hoverable
             >
                 <div
                     className={`${css.statusIndicator} ${getDeviceStatusClass()}`}

--- a/frontend/src/components/Connection/Devices/Devices.module.scss
+++ b/frontend/src/components/Connection/Devices/Devices.module.scss
@@ -4,15 +4,18 @@
 }
 
 .loggedIn {
+    display: flex;
+    align-items: center;
     margin-bottom: var(--space-16);
 }
 
 .notLoggedIn {
+    display: flex;
+    align-items: center;
     margin-left: var(--space-16);
 }
 
 .icon {
     height: calc(var(--font-size-s) * var(--line-height-s));
     margin-left: var(--space-4);
-    vertical-align: top;
 }

--- a/frontend/src/components/Connection/Devices/Devices.tsx
+++ b/frontend/src/components/Connection/Devices/Devices.tsx
@@ -18,10 +18,18 @@ export default function Devices() {
                 <>
                     <div className={css.loggedIn}>
                         Deine registrierten Geräte{" "}
-                        <Tooltip content={"Zu FAQ wechseln: Geräteverwaltung"}>
-                            <Anchor to={"/faq#device-management"}>
-                                <QuestionIcon className={css.icon} />
-                            </Anchor>
+                        <Tooltip
+                            content={
+                                <>
+                                    Zu FAQ wechseln:{" "}
+                                    <Anchor to={"/faq#device-management"}>
+                                        Geräteverwaltung
+                                    </Anchor>
+                                </>
+                            }
+                            hoverable
+                        >
+                            <QuestionIcon className={css.icon} />
                         </Tooltip>
                     </div>
                     <DeviceList />
@@ -29,10 +37,18 @@ export default function Devices() {
             ) : (
                 <div className={css.notLoggedIn}>
                     Melde dich an, um Geräte zu registrieren
-                    <Tooltip content={"Zu FAQ wechseln: Geräteverwaltung"}>
-                        <Anchor to={"/faq#device-management"}>
-                            <QuestionIcon className={css.icon} />
-                        </Anchor>
+                    <Tooltip
+                        content={
+                            <>
+                                Zu FAQ wechseln:{" "}
+                                <Anchor to={"/faq#device-management"}>
+                                    Geräteverwaltung
+                                </Anchor>
+                            </>
+                        }
+                        hoverable
+                    >
+                        <QuestionIcon className={css.icon} />
                     </Tooltip>
                 </div>
             )}

--- a/frontend/src/components/Tooltip/Tooltip.module.scss
+++ b/frontend/src/components/Tooltip/Tooltip.module.scss
@@ -27,6 +27,11 @@
         scale: 1;
     }
 
+    // Only while visible, so the hidden tooltip never blocks clicks underneath.
+    &.hoverable.visible {
+        pointer-events: auto;
+    }
+
     &.top {
         bottom: anchor(top);
         left: anchor(center);

--- a/frontend/src/components/Tooltip/Tooltip.tsx
+++ b/frontend/src/components/Tooltip/Tooltip.tsx
@@ -1,8 +1,12 @@
-import { ReactNode, useId, useState } from "react";
+import { ReactNode, useEffect, useId, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import css from "./Tooltip.module.scss";
 
 export type TooltipPosition = "top" | "bottom" | "left" | "right";
+
+// Grace period before a hoverable tooltip hides, so the pointer can travel
+// from the trigger to the tooltip content.
+const HIDE_DELAY_MS = 200;
 
 interface TooltipProps {
     children: ReactNode;
@@ -11,6 +15,8 @@ interface TooltipProps {
     showArrow?: boolean;
     className?: string;
     disabled?: boolean;
+    /** Keeps the tooltip open while hovered, so its content can be selected and clicked. */
+    hoverable?: boolean;
 }
 
 export default function Tooltip({
@@ -20,18 +26,30 @@ export default function Tooltip({
     showArrow = false,
     className = "",
     disabled = false,
+    hoverable = false,
 }: TooltipProps) {
     const [isVisible, setIsVisible] = useState(false);
+    const hideTimeout = useRef<number | undefined>(undefined);
     const anchorId = useId();
 
+    useEffect(() => () => window.clearTimeout(hideTimeout.current), []);
+
     const handleMouseEnter = () => {
+        window.clearTimeout(hideTimeout.current);
         if (!disabled) {
             setIsVisible(true);
         }
     };
 
     const handleMouseLeave = () => {
-        setIsVisible(false);
+        if (hoverable) {
+            hideTimeout.current = window.setTimeout(
+                () => setIsVisible(false),
+                HIDE_DELAY_MS
+            );
+        } else {
+            setIsVisible(false);
+        }
     };
 
     const tooltipClasses = [
@@ -39,6 +57,7 @@ export default function Tooltip({
         css[position],
         showArrow ? css.withArrow : "",
         isVisible ? css.visible : "",
+        hoverable ? css.hoverable : "",
         className,
     ]
         .filter(Boolean)
@@ -70,6 +89,8 @@ export default function Tooltip({
                         } as React.CSSProperties
                     }
                     data-anchor-id={anchorId}
+                    onMouseEnter={hoverable ? handleMouseEnter : undefined}
+                    onMouseLeave={hoverable ? handleMouseLeave : undefined}
                 >
                     {showArrow && <div className={css.arrow} />}
                     {content}


### PR DESCRIPTION
Der Tooltip erhält ein optionales hoverable-Prop: Beim Verlassen der Trigger-Fläche bleibt er 200ms sichtbar und schließt nicht, solange der Zeiger über dem Inhalt steht. Der Inhalt lässt sich dadurch markieren, kopieren und anklicken. Der FAQ-Link auf der Connect-Seite liegt jetzt im Tooltip und funktioniert.
