### PR TITLE
Dynamische Toast-Positionen unter Header und Anmeldedialog

### DIFF
--- a/frontend/src/components/Auth/AuthDialog.tsx
+++ b/frontend/src/components/Auth/AuthDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, RefObject } from "react";
+import { useState, useEffect, RefObject } from "react";
 import { flushSync } from "react-dom";
 import css from "./AuthDialog.module.scss";
 import RegisterForm from "./RegisterForm";
@@ -31,6 +31,42 @@ export default function AuthDialog({ ref, onClose }: AuthDialogProps) {
 
     const { login, register } = useAuth();
     const resetWebsocketConnection = useResetWebsocket();
+
+    // Mirrors the dialog's bottom edge into --auth-dialog-bottom on the root
+    // element so the toast container can position itself below the open
+    // dialog (see toastify-styles.scss). offsetTop/offsetHeight are layout
+    // values and ignore the scale transform of the open animation.
+    useEffect(() => {
+        const dialog = ref.current;
+
+        const updateToastOffset = () => {
+            if (dialog.open) {
+                document.documentElement.style.setProperty(
+                    "--auth-dialog-bottom",
+                    `${dialog.offsetTop + dialog.offsetHeight}px`
+                );
+            } else {
+                document.documentElement.style.removeProperty(
+                    "--auth-dialog-bottom"
+                );
+            }
+        };
+
+        // Covers open/close (rendered size changes from/to zero) and form
+        // switches that change the dialog height
+        const resizeObserver = new ResizeObserver(updateToastOffset);
+        resizeObserver.observe(dialog);
+        // Covers header height changes that move the anchored dialog
+        window.addEventListener("resize", updateToastOffset);
+
+        return () => {
+            resizeObserver.disconnect();
+            window.removeEventListener("resize", updateToastOffset);
+            document.documentElement.style.removeProperty(
+                "--auth-dialog-bottom"
+            );
+        };
+    }, [ref]);
 
     const switchMode = (newMode: AuthForm) => {
         if (document.startViewTransition) {

--- a/frontend/src/theme/toastify-styles.scss
+++ b/frontend/src/theme/toastify-styles.scss
@@ -20,6 +20,16 @@
         var(--space-16);
 }
 
+.Toastify__toast-container--top-right {
+    // Toasts start below the header, or below the auth dialog while it is
+    // open. --auth-dialog-bottom is maintained by AuthDialog and falls back
+    // to 0px when the dialog is closed, so max() picks the header bottom.
+    position-anchor: --heading;
+    top: calc(
+        max(anchor(bottom), var(--auth-dialog-bottom, 0px)) + var(--space-16)
+    );
+}
+
 .Toastify__toast-container {
     max-height: calc(100vh - 40px);
     scrollbar-width: thin;


### PR DESCRIPTION
Toasts beginnen unterhalb des Headers und verdecken den Anmelden/Registrieren-Button nicht mehr. Bei geöffnetem Anmeldedialog rutschen sie unter dessen Unterkante und folgen dem Dialog bei Größenänderungen (Login/Registrierung-Wechsel, Validierungsfehler, Resize).