### PR TITLE
Add TURN server configurations for improved connectivity in restricti…

### DIFF
--- a/frontend/src/services/WebRTCConnection.ts
+++ b/frontend/src/services/WebRTCConnection.ts
@@ -22,6 +22,16 @@ const serversConfig: RTCConfiguration = {
         {
             urls: "stun:stun.l.google.com:19302",
         },
+        {
+            urls: "turn:global.relay.metered.ca:443",
+            username: "7cfed80f2da5f327b1e8a894",
+            credential: "Uvb5QuG/FHIpdQYA",
+        },
+        {
+            urls: "turns:global.relay.metered.ca:443?transport=tcp",
+            username: "7cfed80f2da5f327b1e8a894",
+            credential: "Uvb5QuG/FHIpdQYA",
+        },
     ],
 };
 


### PR DESCRIPTION
Fälschlicherweise wurden die TURN Server entfernt. Diese wurden wieder eingeführt, warum? Lies nach was TURN macht und wozu: https://www.metered.ca/docs/turn-server-service/what-is-turn